### PR TITLE
chore: fix multiple playkit.js on development env

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,9 @@ module.exports = {
     contentBase: __dirname + "/src"
   },
   resolve: {
+    alias: {
+      'playkit-js': path.resolve('./node_modules/playkit-js')
+    },
     modules: [
       path.resolve(__dirname, "src"),
       "node_modules"


### PR DESCRIPTION
Use webpack alias to make sure that only kaltura-player-js playkit-js SDK is resolved when working with symlinks for local development