### PR TITLE
feat(FEC-7336): set default analyticsd plugins settings

### DIFF
--- a/src/utils/setup-helpers.js
+++ b/src/utils/setup-helpers.js
@@ -103,7 +103,7 @@ function addKalturaPoster(metadata: Object, width: number, height: number): void
 function setDefaultPlayerConfig(playerConfig: Object): void {
   checkNativeHlsSupport(playerConfig);
   checkNativeTextTracksSupport(playerConfig);
-  setDefaultAnalytics(playerConfig);
+  setDefaultAnalyticsPlugin(playerConfig);
 }
 
 /**


### PR DESCRIPTION
### Description of the Changes

Set kanalytics as default enabled plugin with default BE URL.
This should be moved to settings that will be supplied by environment settings via BE.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
