### PR TITLE
fix: remove kanalytics base url

### DIFF
--- a/src/utils/setup-helpers.js
+++ b/src/utils/setup-helpers.js
@@ -149,8 +149,8 @@ function checkNativeTextTracksSupport(playerConfig: Object): void {
  * @returns {void}
  */
 function setDefaultAnalyticsPlugin(playerConfig: any): void {
-  let kanalyticsBeUrl = Utils.Object.getPropertyPath(playerConfig, 'plugins.kanalytics.beUrl');
-  if (typeof kanalyticsBeUrl !== 'string') {
+  let kanalyticsPlugin = Utils.Object.getPropertyPath(playerConfig, 'plugins.kanalytics');
+  if (!kanalyticsPlugin) {
     Utils.Object.mergeDeep(playerConfig, {
       plugins: {
         kanalytics: {}


### PR DESCRIPTION
### Description of the Changes

kanalytics already declares own default base url 
https://github.com/kaltura/playkit-js-kanalytics/blob/631d9b5e18dc66585e568baccd7cd867eb6e138b/src/kanalytics.js#L19
no need declaring it here

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
