### PR TITLE
fix(FEC-7528): multiple players cannot be loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 // @flow
-import 'babel-polyfill' // Important! must be first import to support older browsers compatibility
 import PolyfillManager from './polyfills/polyfill-manager'
 import './polyfills/all'
 import getLogger, {getLogLevel, setLogLevel, LogLevel} from './utils/logger'

--- a/src/polyfills/polyfill-manager.js
+++ b/src/polyfills/polyfill-manager.js
@@ -1,6 +1,10 @@
 // @flow
 import getLogger from '../utils/logger'
 
+if (!window._babelPolyfill){
+  require("babel-polyfill");
+}
+
 export default class PolyfillManager {
   static _polyfills: Array<Function> = [];
   static _logger: any = getLogger('PolyfillManager');


### PR DESCRIPTION
### Description of the Changes

since only one instance of babel-polyfill is allowed, we have to require babel-polyfill conditionally only if not already exist
see https://github.com/babel/babel/issues/4019

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
