### PR TITLE
fix(FEC-7647): uiConfId is 0 in the kanalytics stats

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -26,6 +26,7 @@ export default class KalturaPlayer {
       config: providerConfig.env,
       logLevel: playerConfig.logLevel,
       partnerID: providerConfig.partnerId,
+      uiConfId: providerConfig.uiConfId,
       loadUiConf: providerConfig.loadUiConf
     }
     this._provider = new OvpProvider(providerConf);
@@ -44,6 +45,7 @@ export default class KalturaPlayer {
         setUISeekbarConfig(data, this._uiManager);
         addKalturaPoster(data.metadata, dimensions.width, dimensions.height);
         addKalturaParams(data.sources, this._player);
+        data.plugins = data.plugins ? data.plugins : {};
         Utils.Object.mergeDeep(data.plugins, this._player.config.plugins);
         Utils.Object.mergeDeep(data.session, this._player.config.session);
         evaluatePluginsConfig(data);


### PR DESCRIPTION
1. Added UiConfId to the ovp provider configuration as we don't pass it via the getConfig() anymore (should I remove from the loadMedia function & from the getConfig(..) call? )

2. data.plugins - mergedeep returns nothing if the target object is undefined (like in this case). 
Need to think of a better solution i think... trying to think how to fix it inside mergeDeep.

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
