### PR TITLE
fix: always set default external stream handler

### DIFF
--- a/src/common/utils/external-stream-redirect-helper.js
+++ b/src/common/utils/external-stream-redirect-helper.js
@@ -39,10 +39,8 @@ function configureExternalStreamRedirect(config: Object): void {
     });
     sourceOptions = config.sources.options;
   }
-  if (sourceOptions.forceRedirectExternalStreams) {
-    if (typeof sourceOptions.redirectExternalStreamsHandler !== "function") {
+  if (typeof sourceOptions.redirectExternalStreamsHandler !== "function") {
       sourceOptions.redirectExternalStreamsHandler = getDirectManifestUri;
-    }
   }
 }
 


### PR DESCRIPTION
### Description of the Changes

The default redirect handler should always be setup, as it is a fallback for manifest load error.
If `forceRedirectExternalStreams` it means application wants it to be utilized in advanced, even before an error occurred.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
