### PR TITLE
feat(FEC-8084): add loading spinner while preforming change media

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -149,18 +149,6 @@ function getUrlParameter(name: string) {
 }
 
 /**
- * Sets the media info on error component to the "retry" functionality.
- * @param {UIManager} uiManager - The ui manager.
- * @param {ProviderMediaInfoObject} mediaInfo - The media info.
- * @returns {void}
- */
-function setUIErrorOverlayConfig(uiManager: UIManager, mediaInfo: ProviderMediaInfoObject): void {
-  uiManager.setConfig({
-    mediaInfo: mediaInfo
-  }, "error");
-}
-
-/**
  * Checks if the server UIConf exist
  * @param {number} uiConfId - The server UIConf
  * @returns {boolean} - server UIConf exist
@@ -279,7 +267,6 @@ export {
   createKalturaPlayerContainer,
   checkNativeHlsSupport,
   getDefaultOptions,
-  setUIErrorOverlayConfig,
   isSafari,
   isIos
 };

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -1,7 +1,6 @@
 // @flow
 import {setDefaultAnalyticsPlugin} from 'player-defaults'
 import {Utils, TextStyle, Env} from 'playkit-js'
-import {UIManager} from 'playkit-js-ui'
 import {ValidationErrorType} from './validation-error'
 import StorageManager from '../storage/storage-manager'
 import {setLogLevel as _setLogLevel, LogLevel} from './logger'

--- a/src/common/utils/ui-actions.js
+++ b/src/common/utils/ui-actions.js
@@ -1,0 +1,28 @@
+// @flow
+import {UIManager} from 'playkit-js-ui'
+
+/**
+ * Sets the media info on error component to the "retry" functionality.
+ * @param {UIManager} uiManager - The ui manager.
+ * @param {ProviderMediaInfoObject} mediaInfo - The media info.
+ * @returns {void}
+ */
+function setUIErrorOverlayConfig(uiManager: UIManager, mediaInfo: ProviderMediaInfoObject): void {
+  uiManager.setConfig({
+    mediaInfo: mediaInfo
+  }, 'error');
+}
+
+/**
+ * Sets the loading spinner state.
+ * @param {UIManager} uiManager - The ui manager.
+ * @param {boolean} show - The spinner state.
+ * @returns {void}
+ */
+function setUILoadingSpinnerState(uiManager: UIManager, show: boolean): void {
+  uiManager.setConfig({
+    show: show
+  }, 'loading');
+}
+
+export {setUIErrorOverlayConfig, setUILoadingSpinnerState};

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -4,7 +4,7 @@ import {UIManager} from 'playkit-js-ui'
 import {Provider} from 'playkit-js-providers'
 import getLogger from './common/utils/logger'
 import {addKalturaParams} from './common/utils/kaltura-params'
-import {setUIErrorOverlayConfig} from './common/utils/setup-helpers'
+import {setUIErrorOverlayConfig, setUILoadingSpinnerState} from './common/utils/ui-actions'
 import {evaluatePluginsConfig} from './common/plugins/plugins-config'
 import {addKalturaPoster, setUISeekbarConfig} from 'poster-and-thumbs'
 import './assets/style.css'
@@ -47,6 +47,7 @@ export default class KalturaPlayer {
     this._logger.debug('loadMedia', mediaInfo);
     this._player.reset();
     this._player.loadingMedia = true;
+    setUILoadingSpinnerState(this._uiManager, true);
     setUIErrorOverlayConfig(this._uiManager, mediaInfo);
     return this._provider.getMediaConfig(mediaInfo)
       .then(mediaConfig => {


### PR DESCRIPTION
### Description of the Changes

Before calling the provider to get the media config, update the loading spinner state of the ui manager using the setConfig API.
Also, moved all UI logic to ui-actions file.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
