### PR TITLE
fix(FEC-8228): calculate correct referrer param for inline and iframe embeds

### DIFF
--- a/src/common/plugins/plugins-config.js
+++ b/src/common/plugins/plugins-config.js
@@ -1,6 +1,7 @@
 //@flow
 import pluginsConfig from './plugins-config.json'
 import evaluate from '../utils/evaluate'
+import {getReferrer} from '../utils/kaltura-params'
 import {Utils} from 'playkit-js'
 
 /**
@@ -21,7 +22,8 @@ function evaluatePluginsConfig(options: KalturaPlayerOptionsObject): void {
         sessionId: options.session.id,
         ks: options.session.ks,
         uiConfId: options.session.uiConfId,
-        partnerId: options.session.partnerId
+        partnerId: options.session.partnerId,
+        referrer: getReferrer()
       };
       Object.keys(entryDataModel).forEach(key => {
         if (entryDataModel[key] === undefined) {

--- a/src/common/plugins/plugins-config.json
+++ b/src/common/plugins/plugins-config.json
@@ -15,7 +15,8 @@
     "sessionId": "{{sessionId}}",
     "ks": "{{ks}}",
     "uiConfId": "{{uiConfId}}",
-    "partnerId": "{{partnerId}}"
+    "partnerId": "{{partnerId}}",
+    "referrer": "{{referrer}}"
   },
   "googleAnalytics": {
     "entryId": "{{entryId}}",

--- a/src/common/utils/kaltura-params.js
+++ b/src/common/utils/kaltura-params.js
@@ -76,6 +76,20 @@ function updateSessionIdInUrl(source: Object = {}, sessionId: ?string): void {
 }
 
 /**
+ * @return {string} - The referrer
+ * @private
+ */
+function getReferrer(): string {
+  let referrer;
+  try {
+    referrer = window.parent.document.URL;
+  } catch (e) { // unfriendly iframe
+    referrer = document.referrer;
+  }
+  return btoa(referrer).substr(0, 1000);
+}
+
+/**
  * @param {PKMediaSourceObject} source - source
  * @return {void}
  * @private
@@ -83,7 +97,7 @@ function updateSessionIdInUrl(source: Object = {}, sessionId: ?string): void {
 function addReferrer(source: PKMediaSourceObject): void {
   if (source.url.indexOf(REFERRER) === -1) {
     let delimiter = source.url.indexOf('?') === -1 ? '?' : '&';
-    source.url += delimiter + REFERRER + btoa(document.referrer || document.URL);
+    source.url += delimiter + REFERRER + getReferrer();
   }
 }
 
@@ -123,4 +137,4 @@ function addKalturaParams(player: Player, playerConfig: PartialKalturaPlayerOpti
   });
 }
 
-export {addKalturaParams, handleSessionId, updateSessionIdInUrl, addReferrer, addClientTag}
+export {addKalturaParams, handleSessionId, updateSessionIdInUrl, getReferrer, addReferrer, addClientTag}

--- a/src/common/utils/kaltura-params.js
+++ b/src/common/utils/kaltura-params.js
@@ -86,7 +86,7 @@ function getReferrer(): string {
   } catch (e) { // unfriendly iframe
     referrer = document.referrer;
   }
-  return btoa(referrer).substr(0, 1000);
+  return referrer;
 }
 
 /**
@@ -97,7 +97,8 @@ function getReferrer(): string {
 function addReferrer(source: PKMediaSourceObject): void {
   if (source.url.indexOf(REFERRER) === -1) {
     let delimiter = source.url.indexOf('?') === -1 ? '?' : '&';
-    source.url += delimiter + REFERRER + getReferrer();
+    let referrer = btoa(getReferrer().substr(0, 1000));
+    source.url += delimiter + REFERRER + referrer;
   }
 }
 


### PR DESCRIPTION
### Description of the Changes
* acquire the `referrer` from the `document.URL` unless is an iframe then acquire it from `document.referrer`
* limit the referrer to 1K length 
* pass the referrer to kanalytics plugin via config see https://github.com/kaltura/playkit-js-kanalytics/pull/31

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
