### PR TITLE
fix(FEC-8235): remove default service url from OTT provider and analytics

### DIFF
--- a/src/common/plugins/plugins-config.js
+++ b/src/common/plugins/plugins-config.js
@@ -14,6 +14,9 @@ function evaluatePluginsConfig(options: KalturaPlayerOptionsObject): void {
       pVersion: __VERSION__,
       pName: __NAME__
     };
+    if (options.provider && options.provider.env) {
+      dataModel['serviceUrl'] = options.provider.env.serviceUrl;
+    }
     if (options.session && options.sources) {
       const entryDataModel = {
         entryId: options.sources.id,

--- a/src/common/plugins/plugins-config.js
+++ b/src/common/plugins/plugins-config.js
@@ -10,7 +10,7 @@ import {Utils} from 'playkit-js'
  */
 function evaluatePluginsConfig(options: KalturaPlayerOptionsObject): void {
   if (options.plugins) {
-    const dataModel = {
+    const dataModel: Object = {
       pVersion: __VERSION__,
       pName: __NAME__
     };

--- a/src/common/plugins/plugins-config.json
+++ b/src/common/plugins/plugins-config.json
@@ -27,7 +27,8 @@
   "ottAnalytics": {
     "entryId": "{{entryId}}",
     "ks": "{{ks}}",
-    "partnerId": "{{partnerId}}"
+    "partnerId": "{{partnerId}}",
+    "serviceUrl": "{{serviceUrl}}"
   },
   "ima": {
     "playerVersion": "{{pVersion}}",


### PR DESCRIPTION
### Description of the Changes

pass the `serviceUrl` to ottAnalytics config

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
