### PR TITLE
fix(FEC-8298): SOURCE_SELECTED event triggered before the UI ready when the source provided manually

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -40,13 +40,16 @@ class KalturaPlayer extends FakeEventTarget {
   constructor(options: KPOptionsObject) {
     super();
     this._eventManager = new EventManager();
-    this._localPlayer = loadPlayer(options);
+    const {sources} = options;
+    const noSourcesOptions = Utils.Object.mergeDeep({}, options, {sources: null});
+    this._localPlayer = loadPlayer(noSourcesOptions);
     this._logger = getLogger('KalturaPlayer' + Utils.Generator.uniqueId(5));
     this._uiWrapper = new UIWrapper(this, options);
     this._provider = new Provider(options.provider, __VERSION__);
     this._playlistManager = new PlaylistManager(this, options);
     this._playlistManager.configure(options.playlist);
     Object.values(CoreEventType).forEach(coreEvent => this._eventManager.listen(this._localPlayer, coreEvent, e => this.dispatchEvent(e)));
+    this._localPlayer.configure({sources});
   }
 
   loadMedia(mediaInfo: ProviderMediaInfoObject): Promise<*> {

--- a/test/src/setup.spec.js
+++ b/test/src/setup.spec.js
@@ -85,4 +85,23 @@ describe('setup', function() {
     kalturaPlayer = setup(config);
     kalturaPlayer.textStyle.should.deep.equal(textStyle);
   });
+
+  it('should configure sources', function(done) {
+    const url = 'http://cfvod.kaltura.com/pd/p/2196781/sp/219678100/serveFlavor/entryId/1_afvj3z0u/v/1/flavorId/1_vpmhfzgl/name/a.mp4';
+    config.sources = {
+      progressive: [
+        {
+          id: 'id',
+          mimetype: 'video/mp4',
+          url
+        }
+      ]
+    };
+    kalturaPlayer = setup(config);
+    kalturaPlayer.load();
+    kalturaPlayer.ready().then(() => {
+      kalturaPlayer.src.should.equal(url);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Description of the Changes

postpone the `sources` config after the ui initialization  

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
