### PR TITLE
fix(FEC-7971): change media doesn't work after a critical error

### DIFF
--- a/src/common/ui-wrapper.js
+++ b/src/common/ui-wrapper.js
@@ -30,7 +30,7 @@ class UIWrapper {
 
   resetErrorConfig(mediaInfo: ProviderMediaInfoObject): void {
     this._setErrorPresetConfig(mediaInfo);
-    this._resetErrorState(mediaInfo);
+    this._resetErrorState();
   }
 
   _setErrorPresetConfig(mediaInfo: ProviderMediaInfoObject): void {

--- a/src/common/ui-wrapper.js
+++ b/src/common/ui-wrapper.js
@@ -28,9 +28,19 @@ class UIWrapper {
     this._uiManager.setConfig(config, componentAlias);
   }
 
-  setErrorPresetConfig(mediaInfo: ProviderMediaInfoObject): void {
+  resetErrorConfig(mediaInfo: ProviderMediaInfoObject): void {
+    this._setErrorPresetConfig(mediaInfo);
+    this._resetErrorState(mediaInfo);
+  }
+
+  _setErrorPresetConfig(mediaInfo: ProviderMediaInfoObject): void {
     if (this._disabled) return;
     this.setConfig({mediaInfo: mediaInfo}, 'error');
+  }
+
+  _resetErrorState(): void {
+    if (this._disabled) return;
+    this.setConfig({hasError: false}, 'engine');
   }
 
   setSeekbarConfig(mediaConfig: ProviderMediaConfigObject): void {

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -42,9 +42,8 @@ export default class KalturaPlayer {
 
   loadMedia(mediaInfo: ProviderMediaInfoObject): Promise<*> {
     this._logger.debug('loadMedia', mediaInfo);
-    this._player.reset();
+    this._reset(mediaInfo);
     this._player.loadingMedia = true;
-    this._uiWrapper.setErrorPresetConfig(mediaInfo);
     this._uiWrapper.setLoadingSpinnerState(true);
     return this._provider.getMediaConfig(mediaInfo)
       .then(mediaConfig => this.setMedia(mediaConfig))
@@ -76,5 +75,10 @@ export default class KalturaPlayer {
       }),
       set: undefined
     };
+  }
+
+  _reset(mediaInfo: ProviderMediaInfoObject): void {
+    this._player.reset();
+    this._uiWrapper.resetErrorConfig(mediaInfo);
   }
 }


### PR DESCRIPTION
### Description of the Changes

reset the error state when loading a new media
depends on https://github.com/kaltura/playkit-js-ui/pull/249

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
