### PR TITLE
fix(FEC-8355): on change media the config hold the old seekbar configuration

### DIFF
--- a/src/common/ui-wrapper.js
+++ b/src/common/ui-wrapper.js
@@ -43,9 +43,9 @@ class UIWrapper {
     this.setConfig({hasError: false}, 'engine');
   }
 
-  setSeekbarConfig(mediaConfig: ProviderMediaConfigObject): void {
+  setSeekbarConfig(mediaConfig: ProviderMediaConfigObject, uiConfig: UIOptionsObject): void {
     if (this._disabled) return;
-    const seekbarConfig = Utils.Object.getPropertyPath(this._uiManager, 'config.components.seekbar');
+    const seekbarConfig = Utils.Object.getPropertyPath(uiConfig, 'components.seekbar');
     const previewThumbnailConfig = getPreviewThumbnailConfig(mediaConfig, seekbarConfig);
     this.setConfig(Utils.Object.mergeDeep({}, previewThumbnailConfig, seekbarConfig), 'seekbar');
   }

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -62,7 +62,7 @@ export default class KalturaPlayer {
     Object.keys(this._player.config.plugins).forEach(name => {playerConfig.plugins[name] = {}});
     addKalturaPoster(playerConfig.sources, mediaConfig.sources, this._player.dimensions);
     addKalturaParams(this._player, playerConfig);
-    this._uiWrapper.setSeekbarConfig(mediaConfig);
+    this._uiWrapper.setSeekbarConfig(mediaConfig, this._player.config.ui);
     this._player.configure(playerConfig);
   }
 

--- a/test/src/common/utils/ui-wrapper.spec.js
+++ b/test/src/common/utils/ui-wrapper.spec.js
@@ -21,7 +21,7 @@ describe('UIWrapper', function () {
     TestUtils.removeElement(targetId);
   });
 
-  describe.only('setSeekbarConfig', function () {
+  describe('setSeekbarConfig', function () {
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
       player = loadPlayer();

--- a/test/src/common/utils/ui-wrapper.spec.js
+++ b/test/src/common/utils/ui-wrapper.spec.js
@@ -21,7 +21,7 @@ describe('UIWrapper', function () {
     TestUtils.removeElement(targetId);
   });
 
-  describe('setSeekbarConfig', function () {
+  describe.only('setSeekbarConfig', function () {
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
       player = loadPlayer();
@@ -71,7 +71,7 @@ describe('UIWrapper', function () {
           });
           done();
         });
-      uiWrapper.setSeekbarConfig(mediaConfig);
+      uiWrapper.setSeekbarConfig(mediaConfig, uiConfig);
     });
 
     it('should set the configured thumbs sprite with configured sizes', function (done) {
@@ -90,7 +90,7 @@ describe('UIWrapper', function () {
           });
           done();
         });
-      uiWrapper.setSeekbarConfig(mediaConfig);
+      uiWrapper.setSeekbarConfig(mediaConfig, uiConfig);
     });
 
     it('should set the backend thumbs sprite with default sizes', function (done) {
@@ -103,7 +103,7 @@ describe('UIWrapper', function () {
           config.thumbsSprite.startsWith(mediaConfig.sources.poster).should.be.true;
           done();
         });
-      uiWrapper.setSeekbarConfig(mediaConfig);
+      uiWrapper.setSeekbarConfig(mediaConfig, uiConfig);
     });
 
     it('should set the backend thumbs sprite with configured sizes', function (done) {
@@ -119,7 +119,7 @@ describe('UIWrapper', function () {
           config.thumbsSprite.startsWith(mediaConfig.sources.poster).should.be.true;
           done();
         });
-      uiWrapper.setSeekbarConfig(mediaConfig);
+      uiWrapper.setSeekbarConfig(mediaConfig, uiConfig);
     });
 
     it('should not set seek bar config', function (done) {
@@ -131,7 +131,7 @@ describe('UIWrapper', function () {
           config.should.deep.equal({});
           done();
         });
-      uiWrapper.setSeekbarConfig(mediaConfig);
+      uiWrapper.setSeekbarConfig(mediaConfig, uiConfig);
     });
   });
 });


### PR DESCRIPTION
### Description of the Changes

take the ui config from the player config instead of from the ui config which could be irrelevant 
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
