### PR TITLE
 fix(FEC-8361): plugins config is not updated

### DIFF
--- a/src/common/plugins/plugins-config.js
+++ b/src/common/plugins/plugins-config.js
@@ -60,10 +60,7 @@ function evaluatePluginsConfig(options: KalturaPlayerOptionsObject): void {
     if (options.plugins) {
       Object.keys(options.plugins).forEach((pluginName) => {
         if (options.plugins && options.plugins[pluginName]) {
-          const mergedConfig = Utils.Object.mergeDeep({}, evaluatedConfigObj[pluginName], options.plugins[pluginName]);
-          if (options.plugins) {
-            options.plugins[pluginName] = mergedConfig;
-          }
+          options.plugins[pluginName] = evaluatedConfigObj[pluginName];
         }
       });
     }

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -56,8 +56,8 @@ export default class KalturaPlayer {
     this._logger.debug('setMedia', mediaConfig);
     const playerConfig = Utils.Object.copyDeep(mediaConfig);
     Utils.Object.mergeDeep(playerConfig.sources, this._player.config.sources);
+    Utils.Object.mergeDeep(playerConfig.plugins, this._player.config.plugins);
     Utils.Object.mergeDeep(playerConfig.session, this._player.config.session);
-    Object.keys(this._player.config.plugins).forEach(name => playerConfig.plugins[name] = {});
     addKalturaPoster(playerConfig.sources, mediaConfig.sources, this._player.dimensions);
     addKalturaParams(this._player, playerConfig);
     evaluatePluginsConfig(playerConfig);

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -56,8 +56,8 @@ export default class KalturaPlayer {
     this._logger.debug('setMedia', mediaConfig);
     const playerConfig = Utils.Object.copyDeep(mediaConfig);
     Utils.Object.mergeDeep(playerConfig.sources, this._player.config.sources);
-    Utils.Object.mergeDeep(playerConfig.plugins, this._player.config.plugins);
     Utils.Object.mergeDeep(playerConfig.session, this._player.config.session);
+    Object.keys(this._player.config.plugins).forEach(name => playerConfig.plugins[name] = {});
     addKalturaPoster(playerConfig.sources, mediaConfig.sources, this._player.dimensions);
     addKalturaParams(this._player, playerConfig);
     evaluatePluginsConfig(playerConfig);


### PR DESCRIPTION
### Description of the Changes

plugins config should be re-evaluated every time a new media is loaded/set.
we don't need to take into account the previous config as it will cause the kaltura-player to override the re-evaluated result.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
