### PR TITLE
fix(FEC-8698): when ui is disabled, playNext() called even when playlist isn't configured

### DIFF
--- a/samples/ovp/cast.html
+++ b/samples/ovp/cast.html
@@ -44,8 +44,7 @@
     },
     plugins: {
       ima: {
-        adTagUrl: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator='
-
+        adTagUrl: 'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator=[timestamp]'
       }
     },
     cast: {

--- a/src/common/playlist/playlist-manager.js
+++ b/src/common/playlist/playlist-manager.js
@@ -23,7 +23,6 @@ class PlaylistManager {
   constructor(player: KalturaPlayer, options: KPOptionsObject) {
     this._player = player;
     this._eventManager = new EventManager();
-    this._playlist = new Playlist();
     this._options = {autoContinue: true};
     this._countdown = {duration: 10, showing: true};
     this._playerOptions = options;

--- a/src/common/playlist/playlist-manager.js
+++ b/src/common/playlist/playlist-manager.js
@@ -27,7 +27,6 @@ class PlaylistManager {
     this._options = {autoContinue: true};
     this._countdown = {duration: 10, showing: true};
     this._playerOptions = options;
-    this._addBindings();
   }
 
   /**
@@ -45,6 +44,7 @@ class PlaylistManager {
       Utils.Object.mergeDeep(this._countdown, config.countdown);
       if (config.items && config.items.find(item => !!item.sources)) {
         this._player.dispatchEvent(new FakeEvent(PlaylistEventType.PLAYLIST_LOADED, {playlist: this}));
+        this._addBindings();
         this.playNext();
       }
     }
@@ -58,6 +58,7 @@ class PlaylistManager {
    * @private
    */
   reset() {
+    this._eventManager.removeAll();
     this._playlist = new Playlist();
   }
 

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -85,7 +85,6 @@ class KalturaPlayer extends FakeEventTarget {
   loadPlaylist(playlistInfo: ProviderPlaylistInfoObject, playlistCustomConfig: KPPlaylistConfigObject): Promise<*> {
     this._logger.debug('loadPlaylist', playlistInfo);
     this._uiWrapper.setLoadingSpinnerState(true);
-    this._playlistManager.reset();
     return this._provider
       .getPlaylistConfig(playlistInfo)
       .then(playlistConfig => this._mergePlaylistConfigAndSet(playlistConfig, playlistCustomConfig))
@@ -99,7 +98,6 @@ class KalturaPlayer extends FakeEventTarget {
   loadPlaylistByEntryList(entryList: ProviderEntryListObject, playlistCustomConfig: KPPlaylistConfigObject): Promise<*> {
     this._logger.debug('loadPlaylistByEntryList', entryList);
     this._uiWrapper.setLoadingSpinnerState(true);
-    this._playlistManager.reset();
     return this._provider
       .getEntryListConfig(entryList)
       .then(playlistConfig => this._mergePlaylistConfigAndSet(playlistConfig, playlistCustomConfig))
@@ -116,6 +114,7 @@ class KalturaPlayer extends FakeEventTarget {
     // $FlowFixMe
     evaluatePluginsConfig(config);
     this._localPlayer.configure({plugins: config.plugins});
+    this._playlistManager.reset();
     this._playlistManager.configure(config.playlist);
   }
 


### PR DESCRIPTION
### Description of the Changes

do not call to `addBindings` if playlist isn't configured

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
