### PR TITLE
fix(FEC-8714): 'onclick' handler for iOS is not needed

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -1,6 +1,6 @@
 // @flow
 import {setDefaultAnalyticsPlugin} from 'player-defaults';
-import {Env, TextStyle, Utils, setCapabilities, EngineType} from '@playkit-js/playkit-js';
+import {Env, TextStyle, Utils} from '@playkit-js/playkit-js';
 import {ValidationErrorType} from './validation-error';
 import StorageManager from '../storage/storage-manager';
 import type {LogLevelObject} from './logger';
@@ -124,26 +124,6 @@ function setStorageTextStyle(player: KalturaPlayer): void {
     if (textStyleObj) {
       player.textStyle = Utils.Object.mergeDeep(new TextStyle(), textStyleObj);
     }
-  }
-}
-
-/**
- * Call to setCapabilities on the first UI_CLICKED event
- * @private
- * @param {Player} player - The Kaltura player.
- * @returns {void}
- */
-function attachToFirstClick(player: Player): void {
-  if (isIos()) {
-    const onUIClicked = () => {
-      player.removeEventListener(player.Event.UI.UI_CLICKED, onUIClicked);
-      setCapabilities(EngineType.HTML5, {autoplay: true});
-    };
-    const onSourceSelected = () => {
-      player.removeEventListener(player.Event.SOURCE_SELECTED, onSourceSelected);
-      player.addEventListener(player.Event.UI.UI_CLICKED, onUIClicked);
-    };
-    player.addEventListener(player.Event.SOURCE_SELECTED, onSourceSelected);
   }
 }
 
@@ -392,7 +372,6 @@ export {
   applyStorageSupport,
   applyCastSupport,
   setStorageTextStyle,
-  attachToFirstClick,
   validateConfig,
   setLogLevel,
   createKalturaPlayerContainer,

--- a/src/setup.js
+++ b/src/setup.js
@@ -5,7 +5,6 @@ import {evaluatePluginsConfig} from './common/plugins/plugins-config';
 import {
   applyCastSupport,
   applyStorageSupport,
-  attachToFirstClick,
   getDefaultOptions,
   printSetupMessages,
   setLogLevel,
@@ -33,7 +32,6 @@ function setup(options: PartialKPOptionsObject | LegacyPartialKPOptionsObject): 
   setStorageTextStyle(player);
   applyStorageSupport(player);
   applyCastSupport(defaultOptions, player);
-  attachToFirstClick(player);
   return player;
 }
 


### PR DESCRIPTION
### Description of the Changes

We moved the creation of the video element next to to the autoplay check, which resolved this issue change media issue. so this click handler isn't needed anymore.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
