### PR TITLE
fix(FEC-8719): volume is not in sync when switching between sender-receiver

### DIFF
--- a/src/common/cast/player-snapshot.js
+++ b/src/common/cast/player-snapshot.js
@@ -36,8 +36,6 @@ class PlayerSnapshot {
       playback: {
         startTime: getStartTime(player),
         autoplay: player.currentTime === 0 ? true : !player.paused,
-        volume: player.volume,
-        muted: player.muted,
         audioLanguage: getLanguage(TrackType.AUDIO, player),
         textLanguage: getLanguage(TrackType.TEXT, player)
       }

--- a/src/common/cast/remote-control.js
+++ b/src/common/cast/remote-control.js
@@ -137,7 +137,7 @@ function onRemoteDeviceDisconnected(payload: RemoteDisconnectedPayload): void {
       if (mediaInfo) {
         this.loadMedia(mediaInfo).then(() => {
           this._eventManager.listenOnce(this, this.Event.Core.FIRST_PLAYING, () => {
-            setInitialAttributes.call(this, snapshot);
+            this.textStyle = snapshot.textStyle;
             configurePlayback.call(this, originPlaybackConfig);
             setInitialTracks.call(this, snapshot);
           });
@@ -215,12 +215,6 @@ function configurePlayback(playbackConfig: Object): void {
       autoplay
     }
   });
-}
-
-function setInitialAttributes(snapshot: PlayerSnapshot): void {
-  this.textStyle = snapshot.textStyle;
-  this.volume = snapshot.config.playback.volume;
-  this.muted = snapshot.config.playback.muted;
 }
 
 function setInitialTracks(playbackConfig: Object): void {

--- a/src/common/storage/storage-manager.js
+++ b/src/common/storage/storage-manager.js
@@ -33,13 +33,19 @@ export default class StorageManager {
   static attach(player: Player): void {
     StorageManager._logger.debug('Attach local storage');
     player.addEventListener(player.Event.UI.USER_CLICKED_MUTE, () => {
-      StorageWrapper.setItem(StorageManager.StorageKeys.MUTED, player.muted);
+      if (!player.isCasting()) {
+        StorageWrapper.setItem(StorageManager.StorageKeys.MUTED, player.muted);
+      }
     });
     player.addEventListener(player.Event.UI.USER_CLICKED_UNMUTE, () => {
-      StorageWrapper.setItem(StorageManager.StorageKeys.MUTED, player.muted);
+      if (!player.isCasting()) {
+        StorageWrapper.setItem(StorageManager.StorageKeys.MUTED, player.muted);
+      }
     });
     player.addEventListener(player.Event.UI.USER_CHANGED_VOLUME, () => {
-      StorageWrapper.setItem(StorageManager.StorageKeys.VOLUME, player.volume);
+      if (!player.isCasting()) {
+        StorageWrapper.setItem(StorageManager.StorageKeys.VOLUME, player.volume);
+      }
     });
     player.addEventListener(player.Event.UI.USER_SELECTED_AUDIO_TRACK, event => {
       const audioTrack = event.payload.audioTrack;


### PR DESCRIPTION
### Description of the Changes

We shouldn't save the mute/volume values while casting.


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
