### PR TITLE
fix(FEC-8773): local storage mute state is not updated when user drag volume bar

### DIFF
--- a/src/common/storage/storage-manager.js
+++ b/src/common/storage/storage-manager.js
@@ -44,6 +44,11 @@ export default class StorageManager {
     });
     player.addEventListener(player.Event.UI.USER_CHANGED_VOLUME, () => {
       if (!player.isCasting()) {
+        if (player.volume > 0) {
+          StorageWrapper.setItem(StorageManager.StorageKeys.MUTED, false);
+        } else {
+          StorageWrapper.setItem(StorageManager.StorageKeys.MUTED, true);
+        }
         StorageWrapper.setItem(StorageManager.StorageKeys.VOLUME, player.volume);
       }
     });

--- a/test/src/common/storage/storage-manager.spec.js
+++ b/test/src/common/storage/storage-manager.spec.js
@@ -1,16 +1,38 @@
 import StorageManager from '../../../../src/common/storage/storage-manager';
 import StorageWrapper from '../../../../src/common/storage/storage-wrapper';
+import * as TestUtils from '../../utils/test-utils';
+import {setup} from '../../../../src';
+import {FakeEvent} from '@playkit-js/playkit-js-ui/src/event/fake-event';
+
+const targetId = 'player-placeholder_storage-manager.spec';
 
 describe('StorageManager', function() {
-  let sandbox;
+  let config, player, sandbox;
+  const partnerId = 1091;
+  const entryId = '0_wifqaipd';
+
+  before(function() {
+    TestUtils.createElement('DIV', targetId);
+  });
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
+    config = {
+      targetId: targetId,
+      provider: {
+        partnerId: partnerId
+      }
+    };
   });
 
   afterEach(function() {
     sandbox.restore();
+    TestUtils.removeVideoElementsFromTestPage();
     window.localStorage.clear();
+  });
+
+  after(function() {
+    TestUtils.removeElement(targetId);
   });
 
   it('should return it has no storage', function() {
@@ -67,6 +89,26 @@ describe('StorageManager', function() {
         textLanguage: 'heb',
         audioLanguage: 'eng'
       }
+    });
+  });
+
+  it('should set muted to true/false depends on changed volume', function() {
+    sandbox.stub(StorageWrapper, '_testForLocalStorage').callsFake(() => {
+      StorageWrapper._isLocalStorageAvailable = true;
+    });
+    player = setup(config);
+    player.loadMedia({entryId: entryId}).then(() => {
+      player.muted = true;
+      player.dispatchEvent(new FakeEvent(player.Event.UI.USER_CLICKED_MUTE));
+      StorageManager.getStorageConfig().playback.muted.should.be.true;
+      player.volume = 0.5;
+      player.dispatchEvent(new FakeEvent(player.Event.UI.USER_CHANGED_VOLUME));
+      StorageManager.getStorageConfig().playback.muted.should.be.false;
+      StorageManager.getStorageConfig().playback.volume.should.equals(0.5);
+      player.volume = 0;
+      player.dispatchEvent(new FakeEvent(player.Event.UI.USER_CHANGED_VOLUME));
+      StorageManager.getStorageConfig().playback.muted.should.be.true;
+      StorageManager.getStorageConfig().playback.volume.should.equals(0);
     });
   });
 });

--- a/test/src/common/storage/storage-manager.spec.js
+++ b/test/src/common/storage/storage-manager.spec.js
@@ -2,7 +2,7 @@ import StorageManager from '../../../../src/common/storage/storage-manager';
 import StorageWrapper from '../../../../src/common/storage/storage-wrapper';
 import * as TestUtils from '../../utils/test-utils';
 import {setup} from '../../../../src';
-import {FakeEvent} from '@playkit-js/playkit-js-ui/src/event/fake-event';
+import {FakeEvent} from '@playkit-js/playkit-js';
 
 const targetId = 'player-placeholder_storage-manager.spec';
 


### PR DESCRIPTION
### Description of the Changes

Manipulate the muted value saved in the local storage in case user changed volume.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
