### PR TITLE
fix(FEC-8706): After pre-roll ad playing in cast and disconnect the video starting from beginning (including pre-roll ad)

### DIFF
--- a/src/common/cast/remote-control.js
+++ b/src/common/cast/remote-control.js
@@ -197,7 +197,7 @@ function reconstructPlayerComponents(snapshot: PlayerSnapshot): void {
       imaConfig = {
         adTagUrl: ''
       };
-      this._eventManager.listen(this, this.Event.FIRST_PLAYING, () => this.configure({plugins: {ima: {adTagUrl: adTagUrl}}}));
+      this._eventManager.listen(this, CoreEventType.FIRST_PLAYING, () => this.configure({plugins: {ima: {adTagUrl: adTagUrl}}}));
     }
     Utils.Object.mergeDeep(playerConfig, {plugins: {ima: imaConfig}});
     // Destroy the local player and load new one


### PR DESCRIPTION
### Description of the Changes

In case of VAST pre roll which already played in the receiver - configure empty ad tag so ads won't play again and after playback started configure the origin ad tag.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
