### PR TITLE
fix(FEC-8791): When changing volume in local mode it's not showing the correct rate/state when returning to local mode after casting

### DIFF
--- a/src/common/cast/remote-control.js
+++ b/src/common/cast/remote-control.js
@@ -7,6 +7,7 @@ import {EventType as CoreEventType, FakeEvent, loadPlayer, TrackType, Utils} fro
 import {RemoteAvailablePayload, RemoteConnectedPayload, RemoteDisconnectedPayload} from './remote-payload';
 import {UIWrapper} from '../ui-wrapper';
 import getLogger from '../utils/logger';
+import StorageManager from '../storage/storage-manager';
 
 const logger: any = getLogger('RemoteControl');
 
@@ -216,10 +217,14 @@ function reconstructPlayerComponents(snapshot: PlayerSnapshot): void {
 
 function configurePlayback(playbackConfig: Object): void {
   const {autoplay, startTime} = playbackConfig;
+  const storageConfig = StorageManager.getStorageConfig();
+  const {muted, volume} = storageConfig;
   this.configure({
     playback: {
       startTime,
-      autoplay
+      autoplay,
+      muted,
+      volume
     }
   });
 }


### PR DESCRIPTION
### Description of the Changes

Set the storage config values when disconnecting from the remote player.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
