### PR TITLE
 fix: undefined error incase advertising vast wasn't configured

### DIFF
--- a/src/common/cast/remote-control.js
+++ b/src/common/cast/remote-control.js
@@ -181,7 +181,7 @@ function reconstructPlayerComponents(snapshot: PlayerSnapshot): void {
   // If the local player config contains ima, needs to destroy the player and create it from scratch
   if (playerConfig.plugins && playerConfig.plugins.ima) {
     let imaConfig = {};
-    // Configure ima such that continuous playback with ads will be start properly
+    // If it's a VAST ad we are empty the ad tag so ads won't play and configure it later
     if (playerConfig.cast.advertising && playerConfig.cast.advertising.vast) {
       if (snapshot.config.playback.startTime > 0) {
         const adTagUrl = playerConfig.plugins.ima.adTagUrl;
@@ -199,7 +199,6 @@ function reconstructPlayerComponents(snapshot: PlayerSnapshot): void {
           playAdsAfterTime: snapshot.config.playback.startTime
         }
       };
-      // If it's a VAST ad we are empty the ad tag so ads won't play and configure it later
     }
     Utils.Object.mergeDeep(playerConfig, {plugins: {ima: imaConfig}});
     // Destroy the local player and load new one

--- a/src/common/cast/remote-control.js
+++ b/src/common/cast/remote-control.js
@@ -182,7 +182,15 @@ function reconstructPlayerComponents(snapshot: PlayerSnapshot): void {
   if (playerConfig.plugins && playerConfig.plugins.ima) {
     let imaConfig = {};
     // Configure ima such that continuous playback with ads will be start properly
-    if (!playerConfig.cast.advertising.vast) {
+    if (playerConfig.cast.advertising && playerConfig.cast.advertising.vast) {
+      if (snapshot.config.playback.startTime > 0) {
+        const adTagUrl = playerConfig.plugins.ima.adTagUrl;
+        imaConfig = {
+          adTagUrl: ''
+        };
+        this._eventManager.listen(this, CoreEventType.FIRST_PLAYING, () => this.configure({plugins: {ima: {adTagUrl: adTagUrl}}}));
+      }
+    } else {
       imaConfig = {
         // Needs to wait for engine to create the new ads container
         delayInitUntilSourceSelected: true,
@@ -192,12 +200,6 @@ function reconstructPlayerComponents(snapshot: PlayerSnapshot): void {
         }
       };
       // If it's a VAST ad we are empty the ad tag so ads won't play and configure it later
-    } else if (snapshot.config.playback.startTime > 0) {
-      const adTagUrl = playerConfig.plugins.ima.adTagUrl;
-      imaConfig = {
-        adTagUrl: ''
-      };
-      this._eventManager.listen(this, CoreEventType.FIRST_PLAYING, () => this.configure({plugins: {ima: {adTagUrl: adTagUrl}}}));
     }
     Utils.Object.mergeDeep(playerConfig, {plugins: {ima: imaConfig}});
     // Destroy the local player and load new one


### PR DESCRIPTION
### Description of the Changes

flip if-else and check for ```playerConfig.cast.advertising```

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
