### PR TITLE
feat(FEC-8751): add support for ima playAdsAfterTime setting

### DIFF
--- a/src/common/cast/remote-control.js
+++ b/src/common/cast/remote-control.js
@@ -199,11 +199,7 @@ function reconstructPlayerComponents(snapshot: PlayerSnapshot): void {
     } else {
       imaConfig = {
         // Needs to wait for engine to create the new ads container
-        delayInitUntilSourceSelected: true,
-        adsRenderingSettings: {
-          // We don't want to play ads that already played in the receiver
-          playAdsAfterTime: snapshot.config.playback.startTime
-        }
+        delayInitUntilSourceSelected: true
       };
     }
     Utils.Object.mergeDeep(playerConfig, {plugins: {ima: imaConfig}});


### PR DESCRIPTION
### Description of the Changes

remove skipping ads on cast disconnect, as is already handled in https://github.com/kaltura/playkit-js-ima/pull/87 according the `startTime` configuration.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
