### PR TITLE
fix: remove applicative style

### DIFF
--- a/samples/style.css
+++ b/samples/style.css
@@ -2,7 +2,6 @@ body {
   background-color: #212121;
   padding: 0;
   margin: 0;
-  text-align: center;
 }
 
 #player-placeholder {


### PR DESCRIPTION
### Description of the Changes

Currently we set `text-align: center;` for the `body`, this style is *application* style and hides some bugs from our eyes (e.g. https://github.com/kaltura/playkit-js-ui/pull/327, https://github.com/kaltura/playkit-js-ui/pull/331).    


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
