### PR TITLE
playlist - the thumbnail slices request is missing ks when the item is already played

### DIFF
--- a/src/common/playlist/playlist-manager.js
+++ b/src/common/playlist/playlist-manager.js
@@ -259,7 +259,7 @@ class PlaylistManager {
     if (activeItem.isPlayable()) {
       this._player.reset();
       // $FlowFixMe
-      this._player.setMedia({session: {}, plugins: {}, sources: activeItem.sources});
+      this._player.setMedia({session: this._player.config.session, plugins: {}, sources: activeItem.sources});
       this._player.dispatchEvent(new FakeEvent(PlaylistEventType.PLAYLIST_ITEM_CHANGED, {index, activeItem}));
       return Promise.resolve();
     } else {


### PR DESCRIPTION
### Description of the Changes

pass the current session object to `setMedia` api

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
