### PR TITLE
fix(FEC-8981): playlist doesn't send ott analytics

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -136,7 +136,10 @@ class KalturaPlayer extends FakeEventTarget {
 
   setPlaylist(playlistData: ProviderPlaylistObject, playlistConfig: ?KPPlaylistConfigObject, entryList: ?ProviderEntryListObject): void {
     this._logger.debug('setPlaylist', playlistData);
-    const config = {playlist: playlistData, plugins: this._localPlayer.config.plugins};
+    const config = {playlist: playlistData, plugins: {}};
+    Object.keys(this._localPlayer.config.plugins).forEach(name => {
+      config.plugins[name] = {};
+    });
     // $FlowFixMe
     evaluatePluginsConfig(config);
     this._localPlayer.configure({plugins: config.plugins});


### PR DESCRIPTION
### Description of the Changes

Pass plugins with empty config to evaluation as we do for single media (in `setMedia`)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
