### PR TITLE
fix(FEC-9002): analytics aren't being sent

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -165,8 +165,8 @@ class KalturaPlayer extends FakeEventTarget {
    */
   configure(config: Object = {}): void {
     config = supportLegacyOptions(config);
-    // $FlowFixMe
-    evaluatePluginsConfig(config.plugins, this.config);
+    const configDoctionary = Utils.Object.mergeDeep({}, this.config, config);
+    evaluatePluginsConfig(config.plugins, configDoctionary);
     this._localPlayer.configure(config);
     const uiConfig = config.ui;
     if (uiConfig) {


### PR DESCRIPTION
### Description of the Changes

The entryId is not being evaluated as the dictionary sent to the evaluation was changed and it didn't include the new entry ID.
All analytics plugins are validating that they have a valid entry ID and because they don't then no event is fired.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
