### PR TITLE
fix(FEC-9013): [iOS] - Player doesnt play ads native

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -253,7 +253,6 @@ function getDefaultOptions(options: PartialKPOptionsObject): KPOptionsObject {
   setDefaultAnalyticsPlugin(defaultOptions);
   configureVrDefaultOptions(defaultOptions);
   configureExternalStreamRedirect(defaultOptions);
-  configureDelayAdsInitialization(defaultOptions);
   return defaultOptions;
 }
 
@@ -271,28 +270,6 @@ function checkNativeHlsSupport(options: KPOptionsObject): void {
         playback: {
           preferNative: {
             hls: true
-          }
-        }
-      });
-    }
-  }
-}
-
-/**
- * Configures the delayInitUntilSourceSelected property for the ads plugin based on the runtime platform and the playsinline config value.
- * @private
- * @param {KPOptionsObject} options - kaltura player options
- * @returns {void}
- */
-function configureDelayAdsInitialization(options: KPOptionsObject): void {
-  if (isIos() && options.plugins && options.plugins.ima) {
-    const playsinline = Utils.Object.getPropertyPath(options, 'playback.playsinline');
-    const delayInitUntilSourceSelected = Utils.Object.getPropertyPath(options, 'plugins.ima.delayInitUntilSourceSelected');
-    if ((typeof playsinline !== 'boolean' || playsinline === true) && typeof delayInitUntilSourceSelected !== 'boolean') {
-      Utils.Object.mergeDeep(options, {
-        plugins: {
-          ima: {
-            delayInitUntilSourceSelected: true
           }
         }
       });


### PR DESCRIPTION
### Description of the Changes

set default value in ima plugin (https://github.com/kaltura/playkit-js-ima/pull/103) instead in kaltura player.
delayInitUntilSourceSelected will be set to true always by default.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
