### PR TITLE
fix(FEC-9026): [Player_V3][Flash] - When clicking fullscreen icon in flash, the player area stays in the same size

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -275,7 +275,7 @@ class KalturaPlayer extends FakeEventTarget {
   }
 
   enterFullscreen(fullScreenElementId: ?string): void {
-    const elementId = fullScreenElementId ? fullScreenElementId : this.config.targetId;
+    const elementId = fullScreenElementId ? fullScreenElementId : this.config.ui.targetId;
     this._localPlayer.enterFullscreen(elementId);
   }
 


### PR DESCRIPTION
### Description of the Changes

Fullscreen will apply to kaltura container instead user container.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
