### PR TITLE
fix(FEC-9087): IMA DAI - the pre-roll Ad duration also calculated for start position - the playback started from 10th sec instead of 20th

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -253,6 +253,7 @@ function getDefaultOptions(options: PartialKPOptionsObject): KPOptionsObject {
   setDefaultAnalyticsPlugin(defaultOptions);
   configureVrDefaultOptions(defaultOptions);
   configureLGTVDefaultOptions(defaultOptions);
+  configureDAIDefaultOptions(defaultOptions);
   configureExternalStreamRedirect(defaultOptions);
   return defaultOptions;
 }
@@ -336,6 +337,31 @@ function configureLGTVDefaultOptions(options: KPOptionsObject): void {
     }
     if (typeof delayUntilSourceSelected !== 'boolean') {
       options = Utils.Object.createPropertyPath(options, 'plugins.ima.delayInitUntilSourceSelected', true);
+    }
+  }
+}
+
+/**
+ * Sets default config option for dai plugin
+ * @private
+ * @param {KPOptionsObject} options - kaltura player options
+ * @returns {void}
+ */
+function configureDAIDefaultOptions(options: KPOptionsObject): void {
+  if (options.plugins && options.plugins.imadai && !options.plugins.imadai.disable) {
+    const autoStartLoadConfig = Utils.Object.getPropertyPath(options, 'playback.options.html5.hls.autoStartLoad');
+    if (typeof autoStartLoadConfig !== 'boolean') {
+      Utils.Object.mergeDeep(options, {
+        playback: {
+          options: {
+            html5: {
+              hls: {
+                autoStartLoad: false
+              }
+            }
+          }
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

config hls by default `autoStartLoad:false` to enable https://github.com/kaltura/playkit-js-ima-dai/pull/15 to override the [`startPosition`](https://github.com/video-dev/hls.js/blob/master/docs/API.md#startposition) value.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
