### PR TITLE
fix(FEC-9118): External caption doesn't display on smart TV

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -285,7 +285,7 @@ function checkNativeHlsSupport(options: KPOptionsObject): void {
  * @returns {void}
  */
 function checkNativeTextTracksSupport(options: KPOptionsObject): void {
-  if (isSafari() || isIos()) {
+  if ((isMacOS() && isSafari()) || isIos()) {
     const useNativeTextTrack = Utils.Object.getPropertyPath(options, 'playback.useNativeTextTrack');
     if (typeof useNativeTextTrack !== 'boolean') {
       Utils.Object.mergeDeep(options, {
@@ -408,6 +408,15 @@ function isSafari(): boolean {
 }
 
 /**
+ * Returns true if user agent indicate that os is mac
+ * @private
+ * @returns {boolean} - if browser is Safari
+ */
+function isMacOS(): boolean {
+  return Env.os.name.toLowerCase() === 'Mac OS';
+}
+
+/**
  * Returns true if user agent indicate that browser is Chrome on iOS
  * @private
  * @returns {boolean} - if browser is Chrome on iOS
@@ -422,7 +431,7 @@ function isIos(): boolean {
  * @returns {boolean} - if browser is in LG TV
  */
 function isLGTV(): boolean {
-  return /^(?=.*\bweb0s\b)(?=.*\bsmarttv\b).*$/i.test(Env.ua);
+  return Env.os.name.toLowerCase() === 'web0s';
 }
 
 /**


### PR DESCRIPTION
### Description of the Changes

UA of webos v.2 is fake to safari, added check for mac os to prevent this fake.
LG check is added to UAParser.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
