### PR TITLE
fix(FEC-9114): live doesn't work properly with hls.js on WebOS

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -326,19 +326,21 @@ function configureVrDefaultOptions(options: KPOptionsObject): void {
  * @returns {void}
  */
 function configureLGTVDefaultOptions(options: KPOptionsObject): void {
-  if (isLGTV() && options.plugins && options.plugins.ima) {
-    const imaForceReload = Utils.Object.getPropertyPath(options, 'plugins.ima.forceReloadMediaAfterAds');
-    const delayUntilSourceSelected = Utils.Object.getPropertyPath(options, 'plugins.ima.delayInitUntilSourceSelected');
+  if (isLGTV()) {
     const preferNativeHls = Utils.Object.getPropertyPath(options, 'playback.preferNative.hls');
-
-    if (typeof imaForceReload !== 'boolean') {
-      options = Utils.Object.createPropertyPath(options, 'plugins.ima.forceReloadMediaAfterAds', true);
-    }
     if (typeof preferNativeHls !== 'boolean') {
       options = Utils.Object.createPropertyPath(options, 'playback.preferNative.hls', true);
     }
-    if (typeof delayUntilSourceSelected !== 'boolean') {
-      options = Utils.Object.createPropertyPath(options, 'plugins.ima.delayInitUntilSourceSelected', true);
+    if (options.plugins && options.plugins.ima) {
+      const imaForceReload = Utils.Object.getPropertyPath(options, 'plugins.ima.forceReloadMediaAfterAds');
+      const delayUntilSourceSelected = Utils.Object.getPropertyPath(options, 'plugins.ima.delayInitUntilSourceSelected');
+
+      if (typeof imaForceReload !== 'boolean') {
+        options = Utils.Object.createPropertyPath(options, 'plugins.ima.forceReloadMediaAfterAds', true);
+      }
+      if (typeof delayUntilSourceSelected !== 'boolean') {
+        options = Utils.Object.createPropertyPath(options, 'plugins.ima.delayInitUntilSourceSelected', true);
+      }
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

change default configuration for LG TV to play with native video player by default instead hls/shaka. Currently we use this only when playing ads.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
