### PR TITLE
fix: inBrowserFullscreen path

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -255,7 +255,7 @@ function getDefaultOptions(options: PartialKPOptionsObject): KPOptionsObject {
   configureDAIDefaultOptions(defaultOptions);
   configureBumperDefaultOptions(defaultOptions);
   configureExternalStreamRedirect(defaultOptions);
-  maybeSetDefaultUiComponents(defaultOptions);
+  maybeSetFullScreenConfig(defaultOptions);
   return defaultOptions;
 }
 
@@ -507,7 +507,7 @@ function hasYoutubeSource(sources: PKSourcesConfigObject): boolean {
  * @param {KPOptionsObject} options - kaltura player options
  * @returns {void}
  */
-function maybeSetDefaultUiComponents(options: KPOptionsObject): void {
+function maybeSetFullScreenConfig(options: KPOptionsObject): void {
   const bumperPlugin = Utils.Object.getPropertyPath(options, 'plugins.bumper');
   const vrPlugin = Utils.Object.getPropertyPath(options, 'plugins.vr');
   if ((bumperPlugin && !bumperPlugin.disable) || (vrPlugin && !vrPlugin.disable)) {

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -251,7 +251,6 @@ function getDefaultOptions(options: PartialKPOptionsObject): KPOptionsObject {
   checkNativeHlsSupport(defaultOptions);
   checkNativeTextTracksSupport(defaultOptions);
   setDefaultAnalyticsPlugin(defaultOptions);
-  configureVrDefaultOptions(defaultOptions);
   configureLGTVDefaultOptions(defaultOptions);
   configureDAIDefaultOptions(defaultOptions);
   configureBumperDefaultOptions(defaultOptions);
@@ -294,25 +293,6 @@ function checkNativeTextTracksSupport(options: KPOptionsObject): void {
       Utils.Object.mergeDeep(options, {
         playback: {
           useNativeTextTrack: true
-        }
-      });
-    }
-  }
-}
-
-/**
- * Sets config option fullscreen element for Vr Mode support
- * @private
- * @param {KPOptionsObject} options - kaltura player options
- * @returns {void}
- */
-function configureVrDefaultOptions(options: KPOptionsObject): void {
-  if (options.plugins && options.plugins.vr && !options.plugins.vr.disable) {
-    const fullscreenConfig = Utils.Object.getPropertyPath(options, 'playback.inBrowserFullscreen');
-    if (typeof fullscreenConfig !== 'boolean') {
-      Utils.Object.mergeDeep(options, {
-        playback: {
-          inBrowserFullscreen: true
         }
       });
     }
@@ -528,16 +508,14 @@ function hasYoutubeSource(sources: PKSourcesConfigObject): boolean {
  * @returns {void}
  */
 function maybeSetDefaultUiComponents(options: KPOptionsObject): void {
-  if (isIos() && options.plugins && options.plugins.bumper) {
-    const fullscreenConfig = Utils.Object.getPropertyPath(options, 'ui.components.fullscreen');
-    if (!fullscreenConfig) {
+  const bumperPlugin = Utils.Object.getPropertyPath(options, 'plugins.bumper');
+  const vrPlugin = Utils.Object.getPropertyPath(options, 'plugins.vr');
+  if ((bumperPlugin && !bumperPlugin.disable) || (vrPlugin && !vrPlugin.disable)) {
+    const fullscreenConfig = Utils.Object.getPropertyPath(options, 'playback.inBrowserFullscreen');
+    if (typeof fullscreenConfig !== 'boolean') {
       Utils.Object.mergeDeep(options, {
-        ui: {
-          components: {
-            fullscreen: {
-              inBrowserFullscreenForIOS: true
-            }
-          }
+        playback: {
+          inBrowserFullscreen: true
         }
       });
     }

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -502,7 +502,7 @@ function hasYoutubeSource(sources: PKSourcesConfigObject): boolean {
 }
 
 /**
- * Maybe set the UI component based on the runtime platform and the plugins.
+ * Maybe set inBrowserFullscreen config based on the plugins.
  * @private
  * @param {KPOptionsObject} options - kaltura player options
  * @returns {void}


### PR DESCRIPTION
### Description of the Changes

set `playback.inBrowserFullscreen` instead of `ui.components.fullscreen.inBrowserFullscreenForIOS`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
