### PR TITLE
fix(FEC-9248): load media twice in row wouldn't change the media

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -76,8 +76,8 @@ class KalturaPlayer extends FakeEventTarget {
   setMedia(mediaConfig: ProviderMediaConfigObject): void {
     this._logger.debug('setMedia', mediaConfig);
     const playerConfig = Utils.Object.copyDeep(mediaConfig);
-    Utils.Object.mergeDeep(playerConfig.sources, this._localPlayer.config.sources);
-    Utils.Object.mergeDeep(playerConfig.session, this._localPlayer.config.session);
+    playerConfig.sources = Utils.Object.mergeDeep(this._localPlayer.config.sources, mediaConfig.sources);
+    playerConfig.session = Utils.Object.mergeDeep(this._localPlayer.config.session, mediaConfig.session);
     Object.keys(this._localPlayer.config.plugins).forEach(name => {
       playerConfig.plugins[name] = playerConfig.plugins[name] || {};
     });


### PR DESCRIPTION
### Description of the Changes

keep always the newest source config and session.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
