### PR TITLE
fix(FEC-9260): Autoplay is not working on LG TV

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -362,6 +362,7 @@ function _configureAdsWithMSE(options: KPOptionsObject): void {
  */
 function configureLGTVDefaultOptions(options: KPOptionsObject): void {
   if (isSmartTv()) {
+    //relevant for LG SDK 4 which doesn't support our check for autoplay
     setCapabilities(EngineType.HTML5, {autoplay: true});
     _configureAdsWithMSE(options);
     if (options.plugins && options.plugins.ima) {

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -362,6 +362,7 @@ function _configureAdsWithMSE(options: KPOptionsObject): void {
  */
 function configureLGTVDefaultOptions(options: KPOptionsObject): void {
   if (isSmartTv()) {
+    setCapabilities(EngineType.HTML5, {autoplay: true});
     _configureAdsWithMSE(options);
     if (options.plugins && options.plugins.ima) {
       const imaForceReload = Utils.Object.getPropertyPath(options, 'plugins.ima.forceReloadMediaAfterAds');


### PR DESCRIPTION
### Description of the Changes

LG SDK 4 break their support on base64 source which included in our check for autoplay

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
