### PR TITLE
feat(FEC-9142): getting bumper from provider by entry Id (OVP)

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -584,6 +584,18 @@ function hasYoutubeSource(sources: PKSourcesConfigObject): boolean {
 }
 
 /**
+ * Maybe add the plugins info for the provider
+ * @param {PKPluginsConfigObject} plugins - kaltura player plugins
+ * @param {ProviderMediaInfoObject} mediaInfo - the provider media info
+ * @returns {void}
+ */
+function maybeAddPluginsInfo(plugins: PKPluginsConfigObject = {}, mediaInfo: ProviderMediaInfoObject): void {
+  if (plugins && plugins.bumper && !plugins.bumper.disable && plugins.bumper.id && !plugins.bumper.url) {
+    mediaInfo.bumperId = plugins.bumper.id;
+  }
+}
+
+/**
  * Maybe set inBrowserFullscreen config based on the plugins.
  * @private
  * @param {KPOptionsObject} options - kaltura player options
@@ -620,5 +632,6 @@ export {
   isSafari,
   isIos,
   maybeSetStreamPriority,
-  hasYoutubeSource
+  hasYoutubeSource,
+  maybeAddPluginsInfo
 };

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -1,7 +1,7 @@
 // @flow
 import {EventType as UIEventType} from '@playkit-js/playkit-js-ui';
 import {Provider} from 'playkit-js-providers';
-import {supportLegacyOptions, maybeSetStreamPriority, hasYoutubeSource} from './common/utils/setup-helpers';
+import {supportLegacyOptions, maybeSetStreamPriority, hasYoutubeSource, maybeAddPluginsInfo} from './common/utils/setup-helpers';
 import getLogger from './common/utils/logger';
 import {addKalturaParams} from './common/utils/kaltura-params';
 import {evaluatePluginsConfig, evaluateUIConfig} from './common/plugins/plugins-config';
@@ -56,6 +56,7 @@ class KalturaPlayer extends FakeEventTarget {
     this._logger.debug('loadMedia', mediaInfo);
     this._mediaInfo = mediaInfo;
     this.reset();
+    maybeAddPluginsInfo(this._localPlayer.config.plugins, mediaInfo);
     this._localPlayer.loadingMedia = true;
     this._uiWrapper.setLoadingSpinnerState(true);
     const providerResult = this._provider.getMediaConfig(mediaInfo);


### PR DESCRIPTION
### Description of the Changes

Pass the `bumper.id` to the provider on the `mediaInfo`
Depends on https://github.com/kaltura/playkit-js-providers/pull/88

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
