### PR TITLE
fix(FEC-9137): Samsung smart tv doesn't success playing playready 

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -362,7 +362,7 @@ function _configureAdsWithMSE(options: KPOptionsObject): void {
  * @returns {void}
  */
 function configureLGTVDefaultOptions(options: KPOptionsObject): void {
-  if (isSmartTv()) {
+  if (Env.isSmartTV) {
     //relevant for LG SDK 4 which doesn't support our check for autoplay
     setCapabilities(EngineType.HTML5, {autoplay: true});
     _configureAdsWithMSE(options);
@@ -439,7 +439,7 @@ function configureBumperDefaultOptions(options: KPOptionsObject): void {
     const newBumperConfig: Object = {};
     if (
       typeof bumperConfig.playOnMainVideoTag !== 'boolean' &&
-      (isSmartTv() || (isIos() && options.playback && options.playback.playsinline === false))
+      (Env.isSmartTV || (isIos() && options.playback && options.playback.playsinline === false))
     ) {
       newBumperConfig['playOnMainVideoTag'] = true;
     }
@@ -558,15 +558,6 @@ function isMacOS(): boolean {
  */
 function isIos(): boolean {
   return Env.os.name === 'iOS';
-}
-
-/**
- * Returns true if user agent indicate that browser is smart TV
- * @private
- * @returns {boolean} - if browser is in LG TV
- */
-function isSmartTv(): boolean {
-  return Env.os.name.toLowerCase() === 'web0s' || Env.os.name.toLowerCase() === 'tizen';
 }
 
 /**

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -1,6 +1,6 @@
 // @flow
 import {setDefaultAnalyticsPlugin} from 'player-defaults';
-import {Env, TextStyle, Utils, setCapabilities, EngineType} from '@playkit-js/playkit-js';
+import {Env, TextStyle, Utils, setCapabilities, EngineType, DrmScheme} from '@playkit-js/playkit-js';
 import {ValidationErrorType} from './validation-error';
 import StorageManager from '../storage/storage-manager';
 import type {LogLevelObject} from './logger';
@@ -366,6 +366,11 @@ function configureLGTVDefaultOptions(options: KPOptionsObject): void {
     //relevant for LG SDK 4 which doesn't support our check for autoplay
     setCapabilities(EngineType.HTML5, {autoplay: true});
     _configureAdsWithMSE(options);
+
+    const keySystem = Utils.Object.getPropertyPath(options, 'drm.keySystem');
+    if (typeof keySystem !== 'boolean') {
+      options = Utils.Object.createPropertyPath(options, 'drm.keySystem', DrmScheme.WIDEVINE);
+    }
     if (options.plugins && options.plugins.ima) {
       const imaForceReload = Utils.Object.getPropertyPath(options, 'plugins.ima.forceReloadMediaAfterAds');
       const delayUntilSourceSelected = Utils.Object.getPropertyPath(options, 'plugins.ima.delayInitUntilSourceSelected');

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -368,7 +368,7 @@ function configureLGTVDefaultOptions(options: KPOptionsObject): void {
     _configureAdsWithMSE(options);
 
     const keySystem = Utils.Object.getPropertyPath(options, 'drm.keySystem');
-    if (typeof keySystem !== 'boolean') {
+    if (!keySystem) {
       options = Utils.Object.createPropertyPath(options, 'drm.keySystem', DrmScheme.WIDEVINE);
     }
     if (options.plugins && options.plugins.ima) {


### PR DESCRIPTION
### Description of the Changes

force smart TV to play widevine for now, after updating shaka player it'll be resolved.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
