### PR TITLE
fix(FEC-9362): check for autoplay doesn't work correctly for IPad OS

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -149,7 +149,7 @@ function setStorageTextStyle(player: KalturaPlayer): void {
  * @returns {void}
  */
 function attachToFirstClick(player: Player): void {
-  if (isIos()) {
+  if (isIos() || Env.isIPadOS) {
     const onUIClicked = () => {
       player.removeEventListener(player.Event.UI.UI_CLICKED, onUIClicked);
       setCapabilities(EngineType.HTML5, {autoplay: true});


### PR DESCRIPTION
### Description of the Changes

force IPad OS to setCapabilities autoplay=true after ui clicked.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
