### PR TITLE
fix(FEC-9389): media playing unmuted after unmute fallback

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -149,7 +149,7 @@ function setStorageTextStyle(player: KalturaPlayer): void {
  * @returns {void}
  */
 function attachToFirstClick(player: Player): void {
-  if (isIos()) {
+  if (isIos() || Env.isIPadOS) {
     const onUIClicked = () => {
       player.removeEventListener(player.Event.UI.UI_CLICKED, onUIClicked);
       setCapabilities(EngineType.HTML5, {autoplay: true});


### PR DESCRIPTION
### Description of the Changes

IPAD OS as in IOS capability check failed cause there was user interaction on the player video but there wasn't on the capability check video tag. 
Solved - After clicking on the player video tag set autoplay capability check to true to skip this issue.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
