### PR TITLE
fix(FEC-9366): setMedia doesn't get custom poster as string

### DIFF
--- a/src/common/utils/thumbs.js
+++ b/src/common/utils/thumbs.js
@@ -3,6 +3,8 @@ import evaluate from './evaluate';
 
 export const DEFAULT_THUMBS_WIDTH: number = 164;
 export const DEFAULT_THUMBS_SLICES: number = 100;
+export const THUMBNAIL_REGEX = /.*\/p\/\d+\/(?:[a-zA-Z]+\/\d+\/)*thumbnail\/entry_id\/\w+\/.*\d+/;
+
 const TEMPLATE: string = '{{thumbnailUrl}}/width/{{width}}/vid_slices/{{slices}}/ks/{{ks}}';
 
 /**
@@ -15,8 +17,7 @@ const TEMPLATE: string = '{{thumbnailUrl}}/width/{{width}}/vid_slices/{{slices}}
 export function getThumbSlicesUrl(mediaConfig: ProviderMediaConfigObject, seekbarConfig?: SeekbarConfig): string {
   const mediaConfigPoster = mediaConfig.sources && mediaConfig.sources.poster;
   if (typeof mediaConfigPoster === 'string') {
-    const regex = /.*\/p\/\d+\/(?:[a-zA-Z]+\/\d+\/)*thumbnail\/entry_id\/\w+\/.*\d+/;
-    if (regex.test(mediaConfigPoster)) {
+    if (THUMBNAIL_REGEX.test(mediaConfigPoster)) {
       try {
         const model: Object = {
           thumbnailUrl: mediaConfigPoster,

--- a/src/ovp/poster.js
+++ b/src/ovp/poster.js
@@ -1,4 +1,6 @@
 // @flow
+import {THUMBNAIL_REGEX} from '../common/utils/thumbs';
+
 /**
  * Add poster with player dimensions to thumbnail API call
  * @param {PKSourcesConfigObject} playerSources - player sources container
@@ -12,7 +14,7 @@ function addKalturaPoster(playerSources: PKSourcesConfigObject, mediaSources: Pr
   const mediaConfigPoster = mediaSources.poster;
   const playerWidth = dimensions.width;
   const playerHeight = dimensions.height;
-  if (typeof playerPoster === 'string' && playerPoster === mediaConfigPoster) {
+  if (THUMBNAIL_REGEX.test(playerPoster) && playerPoster === mediaConfigPoster) {
     playerSources.poster = `${playerPoster}/height/${playerHeight}/width/${playerWidth}`;
   }
 }

--- a/src/ovp/poster.js
+++ b/src/ovp/poster.js
@@ -14,7 +14,7 @@ function addKalturaPoster(playerSources: PKSourcesConfigObject, mediaSources: Pr
   const mediaConfigPoster = mediaSources.poster;
   const playerWidth = dimensions.width;
   const playerHeight = dimensions.height;
-  if (THUMBNAIL_REGEX.test(playerPoster) && playerPoster === mediaConfigPoster) {
+  if (typeof playerPoster === 'string' && THUMBNAIL_REGEX.test(playerPoster) && playerPoster === mediaConfigPoster) {
     playerSources.poster = `${playerPoster}/height/${playerHeight}/width/${playerWidth}`;
   }
 }

--- a/test/src/ovp/poster.spec.js
+++ b/test/src/ovp/poster.spec.js
@@ -7,13 +7,20 @@ const targetId = 'player-placeholder_ovp/poster.spec';
 
 describe('addKalturaPoster', function() {
   it('should append width and height to kaltura poster', function() {
+    const mediaSources = {poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2'};
+    const playerSources = {poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2'};
+    addKalturaPoster(playerSources, mediaSources, {width: 640, height: 360});
+    playerSources.poster.should.equal('/p/1091/thumbnail/entry_id/0_wifqaipd/2/height/360/width/640');
+  });
+
+  it('should not append width and height to non kaltura poster', function() {
     const mediaSources = {poster: 'https//my/kaltura/poster'};
     const playerSources = {poster: 'https//my/kaltura/poster'};
     addKalturaPoster(playerSources, mediaSources, {width: 640, height: 360});
-    playerSources.poster.should.equal('https//my/kaltura/poster/height/360/width/640');
+    playerSources.poster.should.equal('https//my/kaltura/poster');
   });
 
-  it('should not append width and height to kaltura poster', function() {
+  it('should not append width and height to configured kaltura poster', function() {
     const mediaSources = {poster: 'https//my/kaltura/poster'};
     const playerSources = {poster: 'https//my/non/kaltura/poster'};
     addKalturaPoster(playerSources, mediaSources, {width: 640, height: 360});


### PR DESCRIPTION
### Description of the Changes

Do not add height and width to non kaltura poster url

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
