### PR TITLE
fix(FEC-9489): IE11 proxy issue in get set methods

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,6 +8,12 @@
   "plugins": [
     "transform-flow-strip-types",
     "transform-class-properties",
+    ["babel-plugin-transform-es2015-classes",
+      {
+        "loose": true
+      }
+    ],
+    "babel-plugin-transform-es5-property-mutators",
     "transform-object-rest-spread"
   ],
   "env": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "babel-loader": "^6.2.7",
     "babel-plugin-istanbul": "^4.0.0",
     "babel-plugin-transform-class-properties": "^6.22.0",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
+    "babel-plugin-transform-es5-property-mutators": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,6 +920,14 @@ babel-plugin-transform-es2015-unicode-regex@^6.22.0, babel-plugin-transform-es20
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
+babel-plugin-transform-es5-property-mutators@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es5-property-mutators/-/babel-plugin-transform-es5-property-mutators-6.24.1.tgz#0b9a24f4e2ff18c33603d24a0d438dc9793b0a13"
+  integrity sha1-C5ok9OL/GMM2A9JKDUONyXk7ChM=
+  dependencies:
+    babel-helper-define-map "^6.24.1"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-exponentiation-operator@^6.22.0, babel-plugin-transform-exponentiation-operator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"


### PR DESCRIPTION
### Description of the Changes

Change the transpile to transpile the es6 get set methods correctly on IE11.

Solve FEC-9489.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
