### PR TITLE
fix(FEC-9632): edge play playready on mac os when it's not supported

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -405,7 +405,11 @@ function configureEdgeDRMDefaultOptions(options: KPOptionsObject): void {
   if (Env.browser.name === 'Edge') {
     const keySystem = Utils.Object.getPropertyPath(options, 'drm.keySystem');
     if (!keySystem) {
-      options = Utils.Object.createPropertyPath(options, 'drm.keySystem', DrmScheme.PLAYREADY);
+      if (Env.os.name === 'Windows') {
+        options = Utils.Object.createPropertyPath(options, 'drm.keySystem', DrmScheme.PLAYREADY);
+      } else {
+        options = Utils.Object.createPropertyPath(options, 'drm.keySystem', DrmScheme.WIDEVINE);
+      }
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

Solution: play playready drm for edge only on windows

Solves FEC-9632

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
