### PR TITLE
fix(FEC-9629): Player is not inline when rendered after the DOM loads

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -287,6 +287,7 @@ function getDefaultOptions(options: PartialKPOptionsObject): KPOptionsObject {
   configureBumperDefaultOptions(defaultOptions);
   configureExternalStreamRedirect(defaultOptions);
   maybeSetFullScreenConfig(defaultOptions);
+  maybeSetCapabilitiesForIos(defaultOptions);
   return defaultOptions;
 }
 
@@ -641,6 +642,19 @@ function maybeSetFullScreenConfig(options: KPOptionsObject): void {
         }
       });
     }
+  }
+}
+
+/**
+ * Set the autoplay capability to false for native Ios player.
+ * @private
+ * @param {KPOptionsObject} options - kaltura player options
+ * @returns {void}
+ */
+function maybeSetCapabilitiesForIos(options: KPOptionsObject): void {
+  const playsinline = Utils.Object.getPropertyPath(options, 'playback.playsinline');
+  if (playsinline === false) {
+    setCapabilities(EngineType.HTML5, {autoplay: false, mutedAutoPlay: false});
   }
 }
 


### PR DESCRIPTION
### Description of the Changes

Set the autoplay capability to `false` for native Ios player.
Thanks https://github.com/kaltura/playkit-js/pull/438 the `runCapability` won't run 

Solves FEC-9629

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
