### PR TITLE
build: add DIST that was missing after release and send npm tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ jobs:
       name: "Release"
       script:
         - currentVersion=$(npx -c 'echo "$npm_package_version"')
-        - yarn run build:ovp && yarn run build:ott && npm run commit:dist
         - chmod +x ./scripts/after_deploy.sh
         - ./scripts/after_deploy.sh "$currentVersion" "$JENKINS_TAG_TOKEN"
     # https://docs.travis-ci.com/user/build-stages/deploy-github-releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ jobs:
       if: (tag IS present)
       name: "Release"
       script:
+        - currentVersion=$(npx -c 'echo "$npm_package_version"')
+        - yarn run build:ovp && yarn run build:ott && npm run commit:dist
         - chmod +x ./scripts/after_deploy.sh
-        - ./scripts/after_deploy.sh "$TRAVIS_TAG" "$JENKINS_TAG_TOKEN"
+        - ./scripts/after_deploy.sh "$currentVersion" "$JENKINS_TAG_TOKEN"
     # https://docs.travis-ci.com/user/build-stages/deploy-github-releases/
     # publish canary package if on master
     - stage: Release canary

--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
     "devMode": {},
     "releaseMode": []
   },
+  "standard-version": {
+    "scripts": {
+      "pretag": "yarn run build:ovp && yarn run build:ott && npm run commit:dist"
+    }
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "standard-version": {
     "scripts": {
-      "pretag": "yarn run build:ovp && yarn run build:ott && npm run commit:dist"
+      "precommit": "yarn run build:ovp && yarn run build:ott && npm run commit:dist"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
### Description of the Changes

TRAVIS_TAG represents with 'v' and we're looking for npm version without 'v' for Jenkins.
build is missing on release, commit dist was missing after post bump was deleted for canary release.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
