### PR TITLE
build: avoid output from pre commit step

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "standard-version": {
     "scripts": {
-      "precommit": "yarn run build:ovp && yarn run build:ott && npm run commit:dist"
+      "precommit": "tmp=$(yarn run build:ovp && yarn run build:ott && npm run commit:dist)"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
### Description of the Changes

set the pre-commit step output into variable to keep the default message

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
