### PR TITLE
fix(FEC-10122): clear playlist manager on reset

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -211,6 +211,7 @@ class KalturaPlayer extends FakeEventTarget {
   }
 
   reset(): void {
+    this._playlistManager.reset();
     this._localPlayer.reset();
     this._uiWrapper.reset();
   }


### PR DESCRIPTION
### Description of the Changes

destroy the playlist manager on reset to avoid a memory leak.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
