### PR TITLE
feat(FEC-9631): add support for out of band text tracks on cast sdk

### DIFF
--- a/src/common/cast/remote-control.js
+++ b/src/common/cast/remote-control.js
@@ -143,6 +143,9 @@ function onRemoteDeviceDisconnected(payload: RemoteDisconnectedPayload): void {
       const mediaConfig = snapshot.mediaConfig;
       snapshot.config.playback.autoplay = true;
       configurePlayback.call(this, snapshot.config.playback);
+      this._eventManager.listenOnce(this, this.Event.Core.CHANGE_SOURCE_ENDED, () => {
+        configureTracks.call(this, snapshot.config.sources);
+      });
       let mediaPromise;
       if (mediaInfo) {
         mediaPromise = this.loadMedia(mediaInfo);
@@ -237,6 +240,17 @@ function configurePlayback(playbackConfig: Object): void {
       autoplay
     }
   });
+}
+
+function configureTracks(sourcesConfig: Object): void {
+  if (sourcesConfig.captions.length) {
+    const {captions} = sourcesConfig;
+    this.configure({
+      sources: {
+        captions
+      }
+    });
+  }
 }
 
 function setInitialTracks(playbackConfig: Object): void {


### PR DESCRIPTION
### Description of the Changes

Update the local player on cast disconnection with the captions from the cast snapshot 

Solves FEC-9631

Related to https://github.com/kaltura/playkit-js-cast-sender/pull/32

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
