### PR TITLE
docs: changing reference of ui customisation to local guide

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -16,6 +16,6 @@
 - [Controlling Errors](errors.md)
 - [Debugging & Troubleshooting](./debugging.md)
 - [How to Build a Plugin](./how-to-build-a-plugin.md)
-- [Customizing the Player CSS](https://github.com/kaltura/playkit-js-ui/blob/master/docs/css-classes-override.md)
+- [Customizing the Player UI](./ui.md)
 - [Keyboard Shortcuts](./keyboard-shortcuts.md)
 - [Coding Guidelines](./coding-guidlines.md)


### PR DESCRIPTION
### Description of the Changes

We now have a Kaltura Player ui.md which describes the ui configuration options. Inside there is a link to the previous css customisation md in the ui repo.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [X] Docs have been updated
