### PR TITLE
fix: old browser(IE11) get method in proxy doesn't work

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,11 @@
     "@babel/plugin-transform-property-mutators",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-transform-classes"
+    ["@babel/plugin-transform-classes",
+      {
+        "loose": true
+      }
+    ]
   ],
   "presets": ["@babel/preset-env", "@babel/preset-flow"]
 }


### PR DESCRIPTION
### Description of the Changes

issue: proxy applied when ui is disable
solution: add loose mode for the class to enable get in the proxy.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
