### PR TITLE
fix(FEC-10455): incorrect order in reset and destroy process

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -238,9 +238,9 @@ class KalturaPlayer extends FakeEventTarget {
       this._reset = true;
       this._firstPlay = true;
       this._playbackStart = false;
-      this._localPlayer.reset();
       this._uiWrapper.reset();
       this._pluginManager.reset();
+      this._localPlayer.reset();
     }
   }
 
@@ -249,11 +249,11 @@ class KalturaPlayer extends FakeEventTarget {
     this._reset = true;
     this._firstPlay = true;
     this._playbackStart = false;
-    this._localPlayer.destroy();
     this._uiWrapper.destroy();
-    this._eventManager.destroy();
-    this._playlistManager.destroy();
     this._pluginManager.destroy();
+    this._playlistManager.destroy();
+    this._localPlayer.destroy();
+    this._eventManager.destroy();
     this._pluginsConfig = {};
     const targetContainer = document.getElementById(targetId);
     if (targetContainer && targetContainer.parentNode) {


### PR DESCRIPTION
### Description of the Changes

Issue: player.destroy() sending invalid 'stop' bookmark with position val 0
Solution: reorder the components destroy/reset since some of them depend on playkit.

Solve: FEC-10455.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
