### PR TITLE
feat(FEC-10435): upgrade Shaka for fixing live issue and optimizations for smartTV

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "js-logger": "^1.6.0",
     "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#v2.22.0",
     "proxy-polyfill": "^0.3.0",
-    "shaka-player": "2.5.13"
+    "shaka-player": "^3.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8542,10 +8542,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaka-player@2.5.13:
-  version "2.5.13"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-2.5.13.tgz#f8c493b825c735fc86d619cba8b2eb2f2a382233"
-  integrity sha512-rEh7juGlTvvF10oD7+EukS12EysZXI2fiGvNLqO7GsBQ5R/sFwcTGEB8A6lWlHQXeGVbT+MxZWKMZwFE805G6A==
+shaka-player@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.4.tgz#241245f4019b3550ef58d6f83b8fc75c66ab8816"
+  integrity sha512-sjmArz8ukKNx5SU2O99kdJr1Z3TyDRn/p11ivUm/67jptCgYuIGI8swfvkJO5KD7MBJSaBP6z32D38dBx5AAxA==
   dependencies:
     eme-encryption-scheme-polyfill "^2.0.1"
 


### PR DESCRIPTION
### Description of the Changes

Issue: encrypted liner channel sometimes constantly changes from buffering to playing
Solution: upgrade shaka - fixes for live and smartTV optimizations - change the default bufferingGoal to 60s as we have for HLS.

Solve: FEC-10435.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
