### PR TITLE
fix(FEC-10468): PLAYBACK_START not fired on autoplay

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@playkit-js/playkit-js": "0.63.0",
+    "@playkit-js/playkit-js": "0.64.0-canary.950da7a",
     "@playkit-js/playkit-js-dash": "1.19.1",
     "@playkit-js/playkit-js-hls": "1.20.0",
     "@playkit-js/playkit-js-ui": "0.58.1",

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -46,7 +46,6 @@ class KalturaPlayer extends FakeEventTarget {
   _pluginsUiComponents: Array<KPUIComponent> = [];
   _reset: boolean = true;
   _firstPlay: boolean = true;
-  _playbackStart: boolean = false;
   _sourceSelected: boolean = false;
 
   constructor(options: KPOptionsObject) {
@@ -214,10 +213,6 @@ class KalturaPlayer extends FakeEventTarget {
   }
 
   play(): void {
-    if (!this._playbackStart) {
-      this._playbackStart = true;
-      this.dispatchEvent(new FakeEvent(CoreEventType.PLAYBACK_START));
-    }
     this._localPlayer.play();
   }
 
@@ -237,7 +232,6 @@ class KalturaPlayer extends FakeEventTarget {
     if (!this._reset) {
       this._reset = true;
       this._firstPlay = true;
-      this._playbackStart = false;
       this._uiWrapper.reset();
       this._pluginManager.reset();
       this._localPlayer.reset();
@@ -248,7 +242,6 @@ class KalturaPlayer extends FakeEventTarget {
     const targetId = this.config.ui.targetId;
     this._reset = true;
     this._firstPlay = true;
-    this._playbackStart = false;
     this._uiWrapper.destroy();
     this._pluginManager.destroy();
     this._playlistManager.destroy();

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -599,6 +599,33 @@ describe('kaltura player api', function () {
   describe('events', function () {
     let player;
 
+    it('should fire PLAYBACK_START on play', done => {
+      player = new Player({
+        ui: {},
+        provider: {}
+      });
+      player.addEventListener(player.Event.PLAYBACK_START, () => {
+        done();
+      });
+      player.play();
+    });
+
+    it('should fire PLAYBACK_START on autoplay', done => {
+      player = new Player({
+        ui: {},
+        provider: {}
+      });
+      player.addEventListener(player.Event.PLAYBACK_START, () => {
+        done();
+      });
+      player.configure({
+        sources: SourcesConfig.Mp4,
+        playback: {
+          autoplay: true
+        }
+      });
+    });
+
     it('should fire auto play failed and show the poster once get AD_AUTOPLAY_FAILED', done => {
       player = new Player({
         ui: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,10 +1159,10 @@
     react-redux "^7.2.0"
     redux "^4.0.5"
 
-"@playkit-js/playkit-js@0.63.0":
-  version "0.63.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.63.0.tgz#01c073dc2067befe57cdca168ea54b8583e07a30"
-  integrity sha512-nJejwY2HQGk/imgqtkma79KOII4F2LIYm5E2irUJHv/8luflCuBwsihX/jD1H+kdkXvB5GjT9v2LHHHbfcj6Sg==
+"@playkit-js/playkit-js@0.64.0-canary.950da7a":
+  version "0.64.0-canary.950da7a"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.64.0-canary.950da7a.tgz#cf194ad49228060b57ce261a410e38051659373e"
+  integrity sha512-iXTHDp4ukDqmhA7AK962aU/O/lvLvRv5wUnWrUzhg+7LhLyr0ULVj9q5uyNzqSZB7zzwO1hmIfwSYsob/WM6AQ==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^0.7.21"


### PR DESCRIPTION
### Description of the Changes

Move `PLAYBACK_START` back to playkit for autoplay flow
(The only reason we moved it to kaltura player is to be aligned with PLAYBACK_ENDED)

Revert part of commit 6217699

Solves FEC-10468

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
