### PR TITLE
build: upgrade provider version to master on canary version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ jobs:
         - yarn upgrade @playkit-js/playkit-js-dash@canary
         - yarn upgrade @playkit-js/playkit-js-hls@canary
         - yarn upgrade @playkit-js/playkit-js-ui@canary
+        - yarn upgrade playkit-js-providers@https://github.com/kaltura/playkit-js-providers.git#master
         - yarn install
         - yarn run build:ovp && yarn run build:ott && npm run commit:dist
         - git push https://$GH_TOKEN@github.com/kaltura/kaltura-player-js "master" > /dev/null 2>&1


### PR DESCRIPTION
### Description of the Changes

Issue: provider doesn't update on the canary version.
Solution: point the version against the master will fetch the updated code.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
