### PR TITLE
fix: incorrect order in import dependencies break IE11

### DIFF
--- a/src/common/polyfills/performance-now.js
+++ b/src/common/polyfills/performance-now.js
@@ -1,17 +1,13 @@
 // @flow
 import PolyfillManager from './polyfill-manager';
-import {getLogger} from '@playkit-js/playkit-js';
 
 export default class PerformanceNowPolyfill {
   static id: string = 'performance.now';
-  static _logger: any = getLogger('PerformanceNowPolyfill');
 
   static install(): void {
     if (global.performance && global.performance.now) {
-      PerformanceNowPolyfill._logger.debug('No need to install polyfill');
       return;
     }
-    PerformanceNowPolyfill._logger.debug('Installing polyfill');
     var startTime = Date.now();
     if (!global.performance) {
       global.performance = {};

--- a/src/common/polyfills/polyfill-manager.js
+++ b/src/common/polyfills/polyfill-manager.js
@@ -1,21 +1,16 @@
 // @flow
-import {getLogger} from '@playkit-js/playkit-js';
-
 if (!window._babelPolyfill) {
   require('@babel/polyfill');
 }
 
 export default class PolyfillManager {
   static _polyfills: Array<Function> = [];
-  static _logger: any = getLogger('PolyfillManager');
 
   static register(polyfill: Function): void {
-    PolyfillManager._logger.debug('Register <' + polyfill.id + '> polyfill');
     PolyfillManager._polyfills.push(polyfill);
   }
 
   static installAll(): void {
-    PolyfillManager._logger.debug('Installing all polyfills');
     for (let i = 0; i < PolyfillManager._polyfills.length; i++) {
       PolyfillManager._polyfills[i].install();
     }

--- a/src/common/polyfills/prepend.js
+++ b/src/common/polyfills/prepend.js
@@ -1,18 +1,14 @@
 // @flow
 import PolyfillManager from './polyfill-manager';
-import {getLogger} from '@playkit-js/playkit-js';
 
 export default class PrependPolyfill {
   static id: string = 'prepend';
-  static _logger: any = getLogger('PrependPolyfill');
 
   static install(): void {
     [Element.prototype, Document.prototype, DocumentFragment.prototype].forEach(function (item) {
       if (Object.prototype.hasOwnProperty.call(item, 'prepend')) {
-        PrependPolyfill._logger.debug('No need to install polyfill on item', item);
         return;
       }
-      PrependPolyfill._logger.debug('Installing polyfill on item', item);
       // $FlowFixMe
       Object.defineProperty(item, 'prepend', {
         configurable: true,

--- a/src/common/storage/storage-manager.js
+++ b/src/common/storage/storage-manager.js
@@ -69,7 +69,7 @@ export default class StorageManager {
         const textStyle = JSON.stringify(event.payload.captionsStyle);
         StorageWrapper.setItem(StorageManager.StorageKeys.TEXT_STYLE, textStyle);
       } catch (e) {
-        this._logger.error(e.message);
+        StorageManager._logger.error(e.message);
       }
     });
 


### PR DESCRIPTION
### Description of the Changes

Issue: getLogger comes from playkit which loads all the imported files in playkit.js, in that moment polyfill doesn't exist yet which causes crash on IE11.
Solution: remove logger from polyfill.
refactor which relocates logger to Kaltura player will return those logs back.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
