### PR TITLE
test: textStyle from kaltura player has get method which doesn't exist on compared object

### DIFF
--- a/test/src/setup.spec.js
+++ b/test/src/setup.spec.js
@@ -81,7 +81,8 @@ describe('setup', function () {
     };
     sandbox.stub(StorageWrapper, 'getItem').withArgs('textStyle').returns(textStyle);
     kalturaPlayer = setup(config);
-    kalturaPlayer.textStyle.should.deep.equal(textStyle);
+    const textStyleObj = JSON.parse(JSON.stringify(kalturaPlayer.textStyle));
+    textStyleObj.should.deep.equal(textStyle);
   });
 
   it('should configure sources', function (done) {


### PR DESCRIPTION
### Description of the Changes

fix deep equal test.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
