### PR TITLE
fix: DRM doesn't play on edge chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "hls.js": "^0.14.9",
     "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#v2.22.2",
     "proxy-polyfill": "^0.3.0",
-    "shaka-player": "^3.0.4"
+    "shaka-player": "^3.0.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8834,10 +8834,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaka-player@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.4.tgz#241245f4019b3550ef58d6f83b8fc75c66ab8816"
-  integrity sha512-sjmArz8ukKNx5SU2O99kdJr1Z3TyDRn/p11ivUm/67jptCgYuIGI8swfvkJO5KD7MBJSaBP6z32D38dBx5AAxA==
+shaka-player@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-3.0.5.tgz#132f959dd61b8c3dbc235ea280304b157e45ff9c"
+  integrity sha512-LYq56q9DA7yTLBD1yQwZrMlJZOovb2yRmo0C3AsddL1J0ee+U4BXr1QZd5amtpBvl8fOiLgkW/12UuChMR764A==
   dependencies:
     eme-encryption-scheme-polyfill "^2.0.1"
 


### PR DESCRIPTION
### Description of the Changes

issue: doesn't play DRM on edge chromium.
Solution: upgrade shaka fix the issue on edge chromium, incorrectly detection of edge browser.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
