### PR TITLE
fix(FEC-10469): pre-roll Ad for playlist displays for each second media instead of for each one

### DIFF
--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -325,7 +325,8 @@ class AdsController extends FakeEventTarget implements IAdsController {
     let playbackEndedHandler;
     const bumperCtrl = this._adsPluginControllers.find(controller => this._isBumper(controller));
     const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));
-    const bumperCompletePromise = bumperCtrl ? bumperCtrl.onPlaybackEnded() : Promise.resolve();
+    const bumperCompletePromise = bumperCtrl && typeof bumperCtrl.onPlaybackEnded === 'function' ? bumperCtrl.onPlaybackEnded() : Promise.resolve();
+    const adCompletePromise = adCtrl && typeof adCtrl.onPlaybackEnded === 'function' ? adCtrl.onPlaybackEnded() : Promise.resolve();
     if (!(this._adBreaksLayout.includes(-1) || this._adBreaksLayout.includes('100%'))) {
       playbackEndedHandler = () => (this._allAdsCompleted = true);
     } else {
@@ -333,9 +334,8 @@ class AdsController extends FakeEventTarget implements IAdsController {
     }
     // $FlowFixMe
     bumperCompletePromise.finally(() => {
-      adCtrl &&
-        // $FlowFixMe
-        adCtrl.onPlaybackEnded().finally(playbackEndedHandler);
+      // $FlowFixMe
+      adCompletePromise.finally(playbackEndedHandler);
     });
   }
 

--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -322,21 +322,20 @@ class AdsController extends FakeEventTarget implements IAdsController {
     if (this._adIsLoading) {
       return;
     }
-    let playbackEndedHandler;
     const bumperCtrl = this._adsPluginControllers.find(controller => this._isBumper(controller));
     const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));
     const bumperCompletePromise = bumperCtrl && typeof bumperCtrl.onPlaybackEnded === 'function' ? bumperCtrl.onPlaybackEnded() : Promise.resolve();
     const adCompletePromise = adCtrl && typeof adCtrl.onPlaybackEnded === 'function' ? adCtrl.onPlaybackEnded() : Promise.resolve();
     if (!(this._adBreaksLayout.includes(-1) || this._adBreaksLayout.includes('100%'))) {
-      playbackEndedHandler = () => (this._allAdsCompleted = true);
+      this._allAdsCompleted = true;
     } else {
-      playbackEndedHandler = () => this._handleConfiguredPostroll();
-    }
-    // $FlowFixMe
-    bumperCompletePromise.finally(() => {
+      const playbackEndedHandler = () => this._handleConfiguredPostroll();
       // $FlowFixMe
-      adCompletePromise.finally(playbackEndedHandler);
-    });
+      bumperCompletePromise.finally(() => {
+        // $FlowFixMe
+        adCompletePromise.finally(playbackEndedHandler);
+      });
+    }
   }
 
   _onPlaybackEnded(): void {

--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -323,7 +323,10 @@ class AdsController extends FakeEventTarget implements IAdsController {
       return;
     }
     if (!(this._adBreaksLayout.includes(-1) || this._adBreaksLayout.includes('100%'))) {
-      this._allAdsCompleted = true;
+      const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));
+      adCtrl.onPlaybackEnded().finally(() => {
+        this._allAdsCompleted = true;
+      });
     } else {
       const bumperCtrl = this._adsPluginControllers.find(controller => this._isBumper(controller));
       const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));

--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -324,9 +324,13 @@ class AdsController extends FakeEventTarget implements IAdsController {
     }
     if (!(this._adBreaksLayout.includes(-1) || this._adBreaksLayout.includes('100%'))) {
       const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));
-      adCtrl.onPlaybackEnded().finally(() => {
+      if (adCtrl) {
+        adCtrl.onPlaybackEnded().finally(() => {
+          this._allAdsCompleted = true;
+        });
+      } else {
         this._allAdsCompleted = true;
-      });
+      }
     } else {
       const bumperCtrl = this._adsPluginControllers.find(controller => this._isBumper(controller));
       const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));


### PR DESCRIPTION
### Description of the Changes

Issue: No pre-roll Ad displays for second media.
Solution: Player should notify ad controller that media is ended as we do for ads with post-rolls, used promise implementation on playback ended.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
