### PR TITLE
fix(FEC-10590): DOM play error on SmartTV on when stall happen on the beginning

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -591,6 +591,11 @@ class KalturaPlayer extends FakeEventTarget {
     this._eventManager.listen(this, CoreEventType.CHANGE_SOURCE_STARTED, () => this._onChangeSourceStarted());
     this._eventManager.listen(this, CoreEventType.ENDED, () => this._onEnded());
     this._eventManager.listen(this, CoreEventType.FIRST_PLAY, () => (this._firstPlay = false));
+    this._eventManager.listen(this, CoreEventType.PLAY_FAILED, () => {
+      if (!Env.isSmartTV) {
+        this.pause();
+      }
+    });
     this._eventManager.listen(this, CoreEventType.SOURCE_SELECTED, () => (this._sourceSelected = true));
     this._eventManager.listen(this, CoreEventType.PLAYBACK_ENDED, () => this._onPlaybackEnded());
     this._eventManager.listen(this, AdEventType.AD_AUTOPLAY_FAILED, (event: FakeEvent) => this._onAdAutoplayFailed(event));

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -29,7 +29,8 @@ import {
   Utils,
   registerEngineDecoratorProvider,
   getLogger,
-  LogLevel
+  LogLevel,
+  Env
 } from '@playkit-js/playkit-js';
 
 class KalturaPlayer extends FakeEventTarget {


### PR DESCRIPTION
### Description of the Changes

handle play failed on Kaltura player to make a pause for non-smart TV.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
