### PR TITLE
fix(FEC-10749): playlist by sources stuck

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -75,7 +75,7 @@ class KalturaPlayer extends FakeEventTarget {
     Object.values(CoreEventType).forEach(coreEvent => this._eventManager.listen(this._localPlayer, coreEvent, e => this.dispatchEvent(e)));
     this._addBindings();
     this._playlistManager.configure(options.playlist);
-    sources && this._localPlayer.configure({sources});
+    this._localPlayer.configure({sources: sources || {}});
   }
 
   /**

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -75,7 +75,7 @@ class KalturaPlayer extends FakeEventTarget {
     Object.values(CoreEventType).forEach(coreEvent => this._eventManager.listen(this._localPlayer, coreEvent, e => this.dispatchEvent(e)));
     this._addBindings();
     this._playlistManager.configure(options.playlist);
-    this._localPlayer.configure({sources});
+    sources && this._localPlayer.configure({sources});
   }
 
   /**

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -42,8 +42,14 @@ describe('kaltura player api', function () {
   });
 
   describe('constructor', function () {
-    it('config.sources should be an empty object if no configured', function () {
+    beforeEach(function () {
       kalturaPlayer = setup(config);
+    });
+
+    afterEach(function () {
+      kalturaPlayer.destroy();
+    });
+    it('config.sources should be an empty object if no configured', function () {
       kalturaPlayer.config.sources.should.be.exist;
     });
   });

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -41,6 +41,12 @@ describe('kaltura player api', function () {
     TestUtils.removeElement(targetId);
   });
 
+  describe('constructor', function () {
+    it('config.sources should be an empty object if no configured', function () {
+      kalturaPlayer = setup(config);
+      kalturaPlayer.config.sources.should.be.exist;
+    });
+  });
   describe('media api', function () {
     describe('loadMedia', function () {
       const entryId = '0_wifqaipd';
@@ -614,6 +620,7 @@ describe('kaltura player api', function () {
       });
     });
   });
+
   describe('async plugins loading', () => {
     let player;
     beforeEach(() => {


### PR DESCRIPTION
### Description of the Changes

Issue: #370 [moved](https://github.com/kaltura/kaltura-player-js/pull/370/files#diff-b20fda8cac0288af75e0f3c4304df5420584de585d923934f9606e3634d2dbf5L302) the redirect default settings from `setup` to `loadMedia`
so `sources` could be `undefined` in kaltura-player constructor  
Solution: pass empty object to `sources` to the local player if it's `undefined`

Solves FEC-10749

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
