### PR TITLE
fix(ads-controller): sources.startTime isn't always exists and can change from source to source

### DIFF
--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -114,7 +114,6 @@ class AdsController extends FakeEventTarget implements IAdsController {
   _init(): void {
     this._initMembers();
     this._addBindings();
-    this._handleConfiguredAdBreaks();
   }
 
   _initMembers(): void {
@@ -128,6 +127,7 @@ class AdsController extends FakeEventTarget implements IAdsController {
   }
 
   _addBindings(): void {
+    this._eventManager.listen(this._player, CustomEventType.SOURCE_SELECTED, () => this._handleConfiguredAdBreaks());
     this._eventManager.listen(this._player, AdEventType.AD_MANIFEST_LOADED, event => this._onAdManifestLoaded(event));
     this._eventManager.listen(this._player, AdEventType.AD_BREAK_START, event => this._onAdBreakStart(event));
     this._eventManager.listen(this._player, AdEventType.AD_LOADED, () => this._onAdLoaded());

--- a/test/src/common/ads/ads-controller.spec.js
+++ b/test/src/common/ads/ads-controller.spec.js
@@ -37,6 +37,7 @@ describe('AdsController', () => {
         }
       });
       player.configure({
+        sources: SourcesConfig.Mp4,
         advertising: {
           adBreaks: [
             {percentage: 0, ads: [{}]},


### PR DESCRIPTION
### Description of the Changes

`sources.startTime` isn't always exists before sources received in the player and also can change from source to source.
Handle the configured ad breaks on `SOURCE_SELECTED` instead on `PLAYER_RESET`.

related to FEC-10686.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
