### PR TITLE
fix(FEC-10967): handle ima dai postroll

### DIFF
--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -341,22 +341,36 @@ class AdsController extends FakeEventTarget implements IAdsController {
     return controller.name === 'bumper';
   }
 
+  _isIMA(controller: IAdsPluginController): boolean {
+    return controller.name === 'ima';
+  }
+
+  _isIMADAI(controller: IAdsPluginController): boolean {
+    return controller.name === 'imadai';
+  }
+
   _onEnded(): void {
     if (this._adIsLoading) {
       return;
     }
     const bumperCtrl = this._adsPluginControllers.find(controller => this._isBumper(controller));
-    const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));
+    const imaCtrl = this._adsPluginControllers.find(controller => this._isIMA(controller));
+    const imaDaiCtrl = this._adsPluginControllers.find(controller => this._isIMADAI(controller));
     const bumperCompleted =
       bumperCtrl && typeof bumperCtrl.onPlaybackEnded === 'function' ? () => bumperCtrl.onPlaybackEnded() : () => Promise.resolve();
-    const adCompleted = adCtrl && typeof adCtrl.onPlaybackEnded === 'function' ? () => adCtrl.onPlaybackEnded() : () => Promise.resolve();
+    const imaCompleted = imaCtrl && typeof imaCtrl.onPlaybackEnded === 'function' ? () => imaCtrl.onPlaybackEnded() : () => Promise.resolve();
+    const imaDaiCompleted =
+      imaDaiCtrl && typeof imaDaiCtrl.onPlaybackEnded === 'function' ? () => imaDaiCtrl.onPlaybackEnded() : () => Promise.resolve();
     if (!(this._adBreaksLayout.includes(-1) || this._adBreaksLayout.includes('100%'))) {
       this._allAdsCompleted = true;
     }
     // $FlowFixMe
-    bumperCompleted().finally(() => {
+    imaDaiCompleted().finally(() => {
       // $FlowFixMe
-      adCompleted().finally(() => this._handleConfiguredPostroll());
+      bumperCompleted().finally(() => {
+        // $FlowFixMe
+        imaCompleted().finally(() => this._handleConfiguredPostroll());
+      });
     });
   }
 


### PR DESCRIPTION
### Description of the Changes

Issue: Ima dai post-roll doesn't work with another ad.
Solution: handle playback ended and let ima dai work with another ad.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
