### PR TITLE
fix(FEC-10968): OTT doesn't have default external-stream-redirect-helper

### DIFF
--- a/src/common/utils/external-stream-redirect-helper.js
+++ b/src/common/utils/external-stream-redirect-helper.js
@@ -1,4 +1,5 @@
 // @flow
+import {Utils} from '@playkit-js/playkit-js';
 
 /**
  * JSONP handler function, returns the direct manifest uri.
@@ -35,4 +36,28 @@ function getDirectManifestUri(data: Object, uri: string): string {
   }
   return uri;
 }
-export {getDirectManifestUri};
+
+/**
+ * Get the redirect external stream handler.
+ * @public
+ * @param {KPOptionsObject} playerOptions - The player config.
+ * @param {KPOptionsObject} mediaOptions - The media config.
+ * @returns {void}
+ */
+function getRedirectExternalStreamsHandler(playerOptions: KPOptionsObject, mediaOptions: KPOptionsObject = {}): Object {
+  const configObj = {};
+  const playerRedirectExternalStreamsHandler = Utils.Object.getPropertyPath(playerOptions, 'sources.options.redirectExternalStreamsHandler');
+  const mediaRedirectExternalStreamsHandler = Utils.Object.getPropertyPath(mediaOptions, 'sources.options.redirectExternalStreamsHandler');
+  if (typeof playerRedirectExternalStreamsHandler !== 'function' && typeof mediaRedirectExternalStreamsHandler !== 'function') {
+    Utils.Object.mergeDeep(configObj, {
+      sources: {
+        options: {
+          redirectExternalStreamsHandler: getDirectManifestUri
+        }
+      }
+    });
+  }
+  return configObj;
+}
+
+export {getRedirectExternalStreamsHandler};

--- a/src/ott/player-defaults.js
+++ b/src/ott/player-defaults.js
@@ -1,5 +1,6 @@
 // @flow
 import {Utils} from '@playkit-js/playkit-js';
+import {getRedirectExternalStreamsHandler} from '../common/utils/external-stream-redirect-helper';
 
 /**
  * Sets the default analytics plugin for the ott player.
@@ -31,8 +32,10 @@ export function setDefaultAnalyticsPlugin(options: KPOptionsObject): void {
 /**
  * get the default config for forcing external stream redirect.
  * @public
+ * @param {KPOptionsObject} playerOptions - The player config.
+ * @param {KPOptionsObject} mediaOptions - The media config.
  * @returns {Object} - config object
  */
-export function getDefaultRedirectOptions(): Object {
-  return {};
+export function getDefaultRedirectOptions(playerOptions: KPOptionsObject, mediaOptions: KPOptionsObject = {}): Object {
+  return Utils.Object.mergeDeep({}, getRedirectExternalStreamsHandler(playerOptions, mediaOptions));
 }

--- a/src/ovp/player-defaults.js
+++ b/src/ovp/player-defaults.js
@@ -1,6 +1,6 @@
 // @flow
 import {Env, Utils, MediaType} from '@playkit-js/playkit-js';
-import {getDirectManifestUri} from '../common/utils/external-stream-redirect-helper';
+import {getRedirectExternalStreamsHandler} from '../common/utils/external-stream-redirect-helper';
 
 /**
  * Sets the default analytics plugin for the ovp player.
@@ -41,16 +41,5 @@ export function getDefaultRedirectOptions(playerOptions: KPOptionsObject, mediaO
       });
     }
   }
-  const playerRedirectExternalStreamsHandler = Utils.Object.getPropertyPath(playerOptions, 'sources.options.redirectExternalStreamsHandler');
-  const mediaRedirectExternalStreamsHandler = Utils.Object.getPropertyPath(mediaOptions, 'sources.options.redirectExternalStreamsHandler');
-  if (typeof playerRedirectExternalStreamsHandler !== 'function' && typeof mediaRedirectExternalStreamsHandler !== 'function') {
-    Utils.Object.mergeDeep(configObj, {
-      sources: {
-        options: {
-          redirectExternalStreamsHandler: getDirectManifestUri
-        }
-      }
-    });
-  }
-  return configObj;
+  return Utils.Object.mergeDeep(configObj, getRedirectExternalStreamsHandler(playerOptions, mediaOptions));
 }

--- a/test/src/ott/player-defaults.spec.js
+++ b/test/src/ott/player-defaults.spec.js
@@ -1,0 +1,28 @@
+import {getDefaultRedirectOptions} from './../../../src/ott/player-defaults';
+
+describe('getDefaultRedirectOptions', function () {
+  let sandbox;
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+  describe('redirectExternalStreamsHandler', function () {
+    it('should return the default', function () {
+      const defaultConfig = getDefaultRedirectOptions({});
+      (typeof defaultConfig.sources.options.redirectExternalStreamsHandler === 'function').should.be.true;
+    });
+
+    it('should return void if already configured on player config', function () {
+      const defaultConfig = getDefaultRedirectOptions({sources: {options: {redirectExternalStreamsHandler: () => {}}}});
+      (defaultConfig.sources === undefined).should.be.true;
+    });
+
+    it('should return void if already configured on media config', function () {
+      const defaultConfig = getDefaultRedirectOptions({}, {sources: {options: {redirectExternalStreamsHandler: () => {}}}});
+      (defaultConfig.sources === undefined).should.be.true;
+    });
+  });
+});

--- a/test/src/ott/player-defaults.spec.js
+++ b/test/src/ott/player-defaults.spec.js
@@ -1,28 +1,33 @@
 import {getDefaultRedirectOptions} from './../../../src/ott/player-defaults';
 
-describe('getDefaultRedirectOptions', function () {
-  let sandbox;
-  beforeEach(function () {
-    sandbox = sinon.createSandbox();
+describe('redirectExternalStreamsHandler', function () {
+  it('should return the default', function () {
+    const defaultConfig = getDefaultRedirectOptions({});
+    (typeof defaultConfig.sources.options.redirectExternalStreamsHandler === 'function').should.be.true;
   });
 
-  afterEach(function () {
-    sandbox.restore();
+  it('should return void if already configured on player config', function () {
+    const defaultConfig = getDefaultRedirectOptions({
+      sources: {
+        options: {
+          redirectExternalStreamsHandler: () => {}
+        }
+      }
+    });
+    (defaultConfig.sources === undefined).should.be.true;
   });
-  describe('redirectExternalStreamsHandler', function () {
-    it('should return the default', function () {
-      const defaultConfig = getDefaultRedirectOptions({});
-      (typeof defaultConfig.sources.options.redirectExternalStreamsHandler === 'function').should.be.true;
-    });
 
-    it('should return void if already configured on player config', function () {
-      const defaultConfig = getDefaultRedirectOptions({sources: {options: {redirectExternalStreamsHandler: () => {}}}});
-      (defaultConfig.sources === undefined).should.be.true;
-    });
-
-    it('should return void if already configured on media config', function () {
-      const defaultConfig = getDefaultRedirectOptions({}, {sources: {options: {redirectExternalStreamsHandler: () => {}}}});
-      (defaultConfig.sources === undefined).should.be.true;
-    });
+  it('should return void if already configured on media config', function () {
+    const defaultConfig = getDefaultRedirectOptions(
+      {},
+      {
+        sources: {
+          options: {
+            redirectExternalStreamsHandler: () => {}
+          }
+        }
+      }
+    );
+    (defaultConfig.sources === undefined).should.be.true;
   });
 });


### PR DESCRIPTION
### Description of the Changes

getting the default `sources.options.redirectExternalStreamsHandler` from common (as before https://github.com/kaltura/kaltura-player-js/pull/370)

Solves FEC-10968

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
