### PR TITLE
fix(FEC-11041): player fails in IE11

### DIFF
--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -15,9 +15,8 @@ class ThumbnailManager {
   _player: Player;
   _thumbnailConfig: ?SeekbarConfig;
 
-  constructor(player: Player, uiConfig: KPUIOptionsObject, mediaConfig: KPMediaConfig) {
+  constructor(player: Player) {
     this._player = player;
-    this._thumbnailConfig = this._buildKalturaThumbnailConfig(uiConfig, mediaConfig);
   }
 
   getThumbnail(time: number): ?ThumbnailInfo {
@@ -27,7 +26,8 @@ class ThumbnailManager {
     return this._player.getThumbnail(time);
   }
 
-  getKalturaThumbnailConfig(): ?SeekbarConfig {
+  getKalturaThumbnailConfig(uiConfig: KPUIOptionsObject, mediaConfig: KPMediaConfig): ?SeekbarConfig {
+    this._thumbnailConfig = this._buildKalturaThumbnailConfig(uiConfig, mediaConfig);
     return this._thumbnailConfig;
   }
 
@@ -55,7 +55,7 @@ class ThumbnailManager {
     const posterUrl = mediaConfig.sources && mediaConfig.sources.poster;
     const isVod = mediaConfig.sources && mediaConfig.sources.type === MediaType.VOD;
     const ks = mediaConfig.session && mediaConfig.session.ks;
-    const thumbnailConfig = Utils.Object.mergeDeep(DefaultThumbnailConfig, seekbarConfig);
+    const thumbnailConfig = Utils.Object.mergeDeep({}, DefaultThumbnailConfig, seekbarConfig);
     const thumbsSprite = isVod ? this._getThumbSlicesUrl(posterUrl, ks, thumbnailConfig) : '';
     return {
       thumbsSprite,

--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -15,8 +15,9 @@ class ThumbnailManager {
   _player: Player;
   _thumbnailConfig: ?SeekbarConfig;
 
-  constructor(player: Player) {
+  constructor(player: Player, uiConfig: KPUIOptionsObject, mediaConfig: KPMediaConfig) {
     this._player = player;
+    this._thumbnailConfig = this._buildKalturaThumbnailConfig(uiConfig, mediaConfig);
   }
 
   getThumbnail(time: number): ?ThumbnailInfo {
@@ -26,8 +27,7 @@ class ThumbnailManager {
     return this._player.getThumbnail(time);
   }
 
-  getKalturaThumbnailConfig(uiConfig: KPUIOptionsObject, mediaConfig: KPMediaConfig): ?SeekbarConfig {
-    this._thumbnailConfig = this._buildKalturaThumbnailConfig(uiConfig, mediaConfig);
+  getKalturaThumbnailConfig(): ?SeekbarConfig {
     return this._thumbnailConfig;
   }
 
@@ -55,7 +55,7 @@ class ThumbnailManager {
     const posterUrl = mediaConfig.sources && mediaConfig.sources.poster;
     const isVod = mediaConfig.sources && mediaConfig.sources.type === MediaType.VOD;
     const ks = mediaConfig.session && mediaConfig.session.ks;
-    const thumbnailConfig = Utils.Object.mergeDeep({}, DefaultThumbnailConfig, seekbarConfig);
+    const thumbnailConfig = Utils.Object.mergeDeep(DefaultThumbnailConfig, seekbarConfig);
     const thumbsSprite = isVod ? this._getThumbSlicesUrl(posterUrl, ks, thumbnailConfig) : '';
     return {
       thumbsSprite,

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -58,7 +58,7 @@ class KalturaPlayer extends FakeEventTarget {
   _appPluginConfig: KPPluginsConfigObject = {};
   _viewabilityManager: ViewabilityManager;
   _playbackStart: boolean;
-  _thumbnailManager: ThumbnailManager = null;
+  _thumbnailManager: ?ThumbnailManager = null;
 
   /**
    * Whether the player browser tab is active and in the scroll view
@@ -472,16 +472,16 @@ class KalturaPlayer extends FakeEventTarget {
   }
 
   getThumbnail(time?: number): ?ThumbnailInfo {
-    if (this._thumbnailManager) {
-      if (!time) {
-        // If time isn't supplied, return thumbnail for player's current time
-        if (!isNaN(this.currentTime)) {
-          time = this.currentTime;
-        } else {
-          return null;
-        }
+    if (!time) {
+      // If time isn't supplied, return thumbnail for player's current time
+      if (!isNaN(this.currentTime)) {
+        time = this.currentTime;
+      } else {
+        return null;
       }
-      time = this.isLive() ? time + this.getStartTimeOfDvrWindow() : time;
+    }
+    time = this.isLive() ? time + this.getStartTimeOfDvrWindow() : time;
+    if (this._thumbnailManager) {
       return this._thumbnailManager.getThumbnail(time);
     }
   }


### PR DESCRIPTION
### Description of the Changes

Getting `Cannot create property for a non-extensible object` error.
must initialise a member so it will create the object with property.
fixes FEC-11041

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
