### PR TITLE
fix: remove thumbnail height from thumbnail service call

### DIFF
--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -9,7 +9,7 @@ const DefaultThumbnailConfig: Object = {
 };
 
 const THUMBNAIL_REGEX = /.*\/p\/\d+\/(?:[a-zA-Z]+\/\d+\/)*thumbnail\/entry_id\/\w+\/.*\d+/;
-const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth}}/height/{{thumbsHeight}}/vid_slices/{{thumbsSlices}}/ks/{{ks}}';
+const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth}}/vid_slices/{{thumbsSlices}}/ks/{{ks}}';
 
 class ThumbnailManager {
   _player: Player;

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -34,7 +34,7 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster}/width/${DefaultThumbnailConfig.thumbsWidth}/height/${DefaultThumbnailConfig.thumbsHeight}/vid_slices/${DefaultThumbnailConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster}/width/${DefaultThumbnailConfig.thumbsWidth}/vid_slices/${DefaultThumbnailConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
       );
   });
 
@@ -50,7 +50,7 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster}/width/${fakeSeekbarConfig.thumbsWidth}/height/${DefaultThumbnailConfig.thumbsHeight}/vid_slices/${fakeSeekbarConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster}/width/${fakeSeekbarConfig.thumbsWidth}/vid_slices/${fakeSeekbarConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
       );
   });
 


### PR DESCRIPTION
### Description of the Changes

remove thumbnail height from thumbnail service call due to BE cache issues.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
