### PR TITLE
fix(FEC-10405): set capabilities manually on iOS devices when airplay is configured

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -649,9 +649,15 @@ function maybeSetFullScreenConfig(options: KPOptionsObject): void {
  * @returns {void}
  */
 function maybeSetCapabilitiesForIos(options: KPOptionsObject): void {
-  const playsinline = Utils.Object.getPropertyPath(options, 'playback.playsinline');
-  if (Env.device.model === 'iPhone' && playsinline === false) {
-    setCapabilities(EngineType.HTML5, {autoplay: false, mutedAutoPlay: false});
+  if (Env.isIOS) {
+    const playsinline = Utils.Object.getPropertyPath(options, 'playback.playsinline');
+    const isAirPlayConfigured = Utils.Object.hasPropertyPath(options, 'plugins.airplay');
+    const isPlaysinline = playsinline !== false;
+    if (isAirPlayConfigured) {
+      setCapabilities(EngineType.HTML5, {autoplay: false, mutedAutoPlay: isPlaysinline});
+    } else if (Env.device.model === 'iPhone' && !isPlaysinline) {
+      setCapabilities(EngineType.HTML5, {autoplay: false, mutedAutoPlay: false});
+    }
   }
 }
 


### PR DESCRIPTION
### Description of the Changes

Airplay on iOS devices won't work if we are enabling the capabilities check.
If airplay is configured, set the capabilities automatically as follows:
1. `autoplay: false`
2. `mutedAutoplay:` depends on the `playsinline` property.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
