### PR TITLE
fix(FEC-11057): ima postroll doesn't play when imadai configured before

### DIFF
--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -346,7 +346,7 @@ class AdsController extends FakeEventTarget implements IAdsController {
       return;
     }
     const bumperCtrl = this._adsPluginControllers.find(controller => this._isBumper(controller));
-    const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller));
+    const adCtrl = this._adsPluginControllers.find(controller => !this._isBumper(controller) && !controller.done);
     const bumperCompleted =
       bumperCtrl && typeof bumperCtrl.onPlaybackEnded === 'function' ? () => bumperCtrl.onPlaybackEnded() : () => Promise.resolve();
     const adCompleted = adCtrl && typeof adCtrl.onPlaybackEnded === 'function' ? () => adCtrl.onPlaybackEnded() : () => Promise.resolve();


### PR DESCRIPTION
### Description of the Changes

Issue: DAI and IMA exist so it selects the first plugin, ima dai for example and then it won't play the post-roll.
Solution: get the Ads controller that is not in DONE state.


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
