### PR TITLE
fix(FEC-11062): ad layout doesn't work when IMA DAI configured

### DIFF
--- a/flow-typed/interfaces/ads-plugin-controller.js
+++ b/flow-typed/interfaces/ads-plugin-controller.js
@@ -2,6 +2,7 @@
 
 declare interface IAdsPluginController {
   skipAd(): void;
+  playAdNow?: (adPod: KPAdPod) => void;
   onPlaybackEnded(): Promise<void>;
   +active: boolean;
   +done: boolean;

--- a/flow-typed/interfaces/ads-plugin-controller.js
+++ b/flow-typed/interfaces/ads-plugin-controller.js
@@ -2,7 +2,6 @@
 
 declare interface IAdsPluginController {
   skipAd(): void;
-  playAdNow(adPod: KPAdPod): void;
   onPlaybackEnded(): Promise<void>;
   +active: boolean;
   +done: boolean;

--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -280,7 +280,7 @@ class AdsController extends FakeEventTarget implements IAdsController {
   }
 
   _playAdBreak(adBreak: RunTimeAdBreakObject): void {
-    const adController = this._adsPluginControllers.find(controller => !this._isBumper(controller));
+    const adController = this._adsPluginControllers.find(controller => !this._isBumper(controller) && typeof controller.playAdNow === 'function');
     if (adController) {
       adBreak.played = true;
       this._adIsLoading = true;

--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -281,7 +281,7 @@ class AdsController extends FakeEventTarget implements IAdsController {
 
   _playAdBreak(adBreak: RunTimeAdBreakObject): void {
     const adController = this._adsPluginControllers.find(controller => !this._isBumper(controller) && typeof controller.playAdNow === 'function');
-    if (adController) {
+    if (adController && typeof adController.playAdNow === 'function') {
       adBreak.played = true;
       this._adIsLoading = true;
       AdsController._logger.debug(`Playing ad break positioned in ${adBreak.position}`);

--- a/src/common/controllers/ads-controller.js
+++ b/src/common/controllers/ads-controller.js
@@ -280,11 +280,12 @@ class AdsController extends FakeEventTarget implements IAdsController {
   }
 
   _playAdBreak(adBreak: RunTimeAdBreakObject): void {
-    const adController = this._adsPluginControllers.find(controller => !this._isBumper(controller) && typeof controller.playAdNow === 'function');
-    if (adController && typeof adController.playAdNow === 'function') {
+    const adController = this._adsPluginControllers.find(controller => typeof controller.playAdNow === 'function');
+    if (adController) {
       adBreak.played = true;
       this._adIsLoading = true;
       AdsController._logger.debug(`Playing ad break positioned in ${adBreak.position}`);
+      // $FlowFixMe
       adController.playAdNow(adBreak.ads);
     } else {
       AdsController._logger.warn('No ads plugin registered');


### PR DESCRIPTION
### Description of the Changes

Issue: play ad now to use the active plugin with play ad now API.
Solution: instead of empty implementation on ad plugins, implement it only where it's needed, and check if there's plugin with this API available to play the ad.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
