### PR TITLE
fix(FEC-11089): bumper preroll doesn't play after ima preroll

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -707,7 +707,8 @@ class KalturaPlayer extends FakeEventTarget {
         const {
           payload: {ad}
         } = event;
-        if (ad && ad.linear && ad.position === 1 && !ad.inStream) {
+        // source set only after media loaded
+        if (ad && ad.linear && ad.position === 1 && !ad.inStream && this.src) {
           this._attachEventManager.listenOnce(this, AdEventType.AD_BREAK_START, () => this.detachMediaSource());
           this._attachEventManager.listenOnce(this, AdEventType.AD_BREAK_END, () => this.attachMediaSource());
           this._attachEventManager.listenOnce(this, AdEventType.AD_ERROR, () => this.attachMediaSource());


### PR DESCRIPTION
### Description of the Changes

Issue: bumper preroll doesn't play after ima preroll with playAdsWithMSE.
Solution: playAdsWithMSE detach/attach also for pre-roll, attach/detach should take control only when the media loaded.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
