### PR TITLE
fix(FEC-11126): moved useShakaTextTrackDisplay from playback.options.playback.options.html5.dash to text

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@playkit-js/playkit-js": "https://github.com/kaltura/playkit-js#master",
+    "@playkit-js/playkit-js": "canary",
     "@playkit-js/playkit-js-dash": "1.23.0",
     "@playkit-js/playkit-js-hls": "1.24.0",
     "@playkit-js/playkit-js-ui": "0.65.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@playkit-js/playkit-js": "0.69.0",
+    "@playkit-js/playkit-js": "https://github.com/kaltura/playkit-js#master",
     "@playkit-js/playkit-js-dash": "1.23.0",
     "@playkit-js/playkit-js-hls": "1.24.0",
     "@playkit-js/playkit-js-ui": "0.65.0",

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -336,7 +336,7 @@ function checkNativeHlsSupport(options: KPOptionsObject): void {
  * @returns {void}
  */
 function checkNativeTextTracksSupport(options: KPOptionsObject): void {
-  if ((Env.isMacOS && Env.isSafari) || Env.isIOS) {
+  if ((Env.isMacOS && Env.isSafari) || Env.isIOS || options.text.useShakaTextTrackDisplay) {
     const useNativeTextTrack = Utils.Object.getPropertyPath(options, 'text.useNativeTextTrack');
     if (typeof useNativeTextTrack !== 'boolean') {
       Utils.Object.mergeDeep(options, {

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -336,7 +336,7 @@ function checkNativeHlsSupport(options: KPOptionsObject): void {
  * @returns {void}
  */
 function checkNativeTextTracksSupport(options: KPOptionsObject): void {
-  if ((Env.isMacOS && Env.isSafari) || Env.isIOS || options.text.useShakaTextTrackDisplay) {
+  if ((Env.isMacOS && Env.isSafari) || Env.isIOS || (options.text && options.text.useShakaTextTrackDisplay)) {
     const useNativeTextTrack = Utils.Object.getPropertyPath(options, 'text.useNativeTextTrack');
     if (typeof useNativeTextTrack !== 'boolean') {
       Utils.Object.mergeDeep(options, {

--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -564,6 +564,7 @@ function supportLegacyOptions(options: Object): PartialKPOptionsObject {
     ['ui.components.fullscreen.inBrowserFullscreenForIOS', 'playback.inBrowserFullscreen'],
     ['playback.enableCEA708Captions', 'text.enableCEA708Captions'],
     ['playback.useNativeTextTrack', 'text.useNativeTextTrack'],
+    ['playback.options.html5.dash.useShakaTextTrackDisplay', 'text.useShakaTextTrackDisplay'],
     ['playback.captionsTextTrack1Label', 'text.captionsTextTrack1Label'],
     ['playback.captionsTextTrack1LanguageCode', 'text.captionsTextTrack1LanguageCode'],
     ['playback.captionsTextTrack2Label', 'text.captionsTextTrack2Label'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,10 +1150,9 @@
     react-redux "^7.2.0"
     redux "^4.0.5"
 
-"@playkit-js/playkit-js@0.69.0":
+"@playkit-js/playkit-js@https://github.com/kaltura/playkit-js#master":
   version "0.69.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.69.0.tgz#21d53583350bc3804b8e2da7cd91ce9eb9507f9a"
-  integrity sha512-sWq/hZ3D2PGALOT2GTwJgKuKY1Kf5O9sjYjACeSissBN4VtPso/DzSOdlb3WDDMP3IF578zseHgQHn9mA9ABjg==
+  resolved "https://github.com/kaltura/playkit-js#26cfe24a22e34aeb6aef5751025464a15d5757cc"
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^0.7.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,9 +1150,10 @@
     react-redux "^7.2.0"
     redux "^4.0.5"
 
-"@playkit-js/playkit-js@https://github.com/kaltura/playkit-js#master":
-  version "0.69.0"
-  resolved "https://github.com/kaltura/playkit-js#26cfe24a22e34aeb6aef5751025464a15d5757cc"
+"@playkit-js/playkit-js@canary":
+  version "0.69.1-canary.26cfe24"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.69.1-canary.26cfe24.tgz#9ad7dcfd7e6f3696e6d1d5d7b5ede679f9945e6e"
+  integrity sha512-w/FWKYcPq4IVjWyX+6/7npA486G4Fdo3gnyqE6JAhMfY7EghFyLY6bYLwnalePqUPaSXUjsZdKSgY0/5T/JAKQ==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^0.7.21"


### PR DESCRIPTION
### Description of the Changes
Added backward support to in setup-helper

depends on https://github.com/kaltura/playkit-js-dash/pull/139
solves FEC-11126

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
