### PR TITLE
fix(FEC-11304): missing entryId on plugins

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -174,8 +174,7 @@ class KalturaPlayer extends FakeEventTarget {
     if (!hasYoutubeSource(sources)) {
       this._thumbnailManager = new ThumbnailManager(this._localPlayer, this.config.ui, mediaConfig);
     }
-    this._localPlayer.setSources(sources || {});
-    this.configure(playerConfig);
+    this.configure({...playerConfig, sources});
   }
 
   /**

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -1049,6 +1049,21 @@ describe('kaltura player api', function () {
         });
       });
 
+      it('should evaluate the plugin config on source selected', done => {
+        player.addEventListener(player.Event.SOURCE_SELECTED, () => {
+          try {
+            player.plugins.colors.config.entryId.should.equals(entryId);
+            player.plugins.colors.config.partnerId.should.equals(1091);
+            player.plugins.colors.config.entryName.should.equals('Vod');
+            player.plugins.colors.config.entryType.should.equals('custom');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+        player.loadMedia({entryId});
+      });
+
       it('should evaluate the configured plugin config - second media', done => {
         player.loadMedia({entryId}).then(() => {
           player.configure({

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -1051,17 +1051,15 @@ describe('kaltura player api', function () {
 
       it('should plugin from setMedia be available after sources selected', done => {
         PluginManager.register('numbers', NumbersPlugin);
-        player.addEventListener(player.Event.SOURCE_SELECTED, () => {
-          try {
-            (player.plugins.numbers !== undefined).should.be.true;
-            (player.plugins.numbers !== null).should.be.true;
-            player.plugins.numbers.should.be.instanceOf(NumbersPlugin);
-            done();
-          } catch (e) {
-            done(e);
-          }
-        });
         player.setMedia({sources: SourcesConfig.Mp4, plugins: {numbers: {}}});
+        try {
+          (player.plugins.numbers !== undefined).should.be.true;
+          (player.plugins.numbers !== null).should.be.true;
+          player.plugins.numbers.should.be.instanceOf(NumbersPlugin);
+          done();
+        } catch (e) {
+          done(e);
+        }
         PluginManager.unRegister('numbers', NumbersPlugin);
       });
 

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -1049,6 +1049,22 @@ describe('kaltura player api', function () {
         });
       });
 
+      it('should plugin from setMedia be available after sources selected', done => {
+        PluginManager.register('numbers', NumbersPlugin);
+        player.addEventListener(player.Event.SOURCE_SELECTED, () => {
+          try {
+            (player.plugins.numbers !== undefined).should.be.true;
+            (player.plugins.numbers !== null).should.be.true;
+            player.plugins.numbers.should.be.instanceOf(NumbersPlugin);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+        player.setMedia({sources: SourcesConfig.Mp4, plugins: {numbers: {}}});
+        PluginManager.unRegister('numbers', NumbersPlugin);
+      });
+
       it('should evaluate the plugin config on source selected', done => {
         player.addEventListener(player.Event.SOURCE_SELECTED, () => {
           try {

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -1049,17 +1049,12 @@ describe('kaltura player api', function () {
         });
       });
 
-      it('should plugin from setMedia be available after sources selected', done => {
+      it('should plugin from setMedia be available after sources selected', () => {
         PluginManager.register('numbers', NumbersPlugin);
         player.setMedia({sources: SourcesConfig.Mp4, plugins: {numbers: {}}});
-        try {
-          (player.plugins.numbers !== undefined).should.be.true;
-          (player.plugins.numbers !== null).should.be.true;
-          player.plugins.numbers.should.be.instanceOf(NumbersPlugin);
-          done();
-        } catch (e) {
-          done(e);
-        }
+        (player.plugins.numbers !== undefined).should.be.true;
+        (player.plugins.numbers !== null).should.be.true;
+        player.plugins.numbers.should.be.instanceOf(NumbersPlugin);
         PluginManager.unRegister('numbers', NumbersPlugin);
       });
 


### PR DESCRIPTION
### Description of the Changes

Issue: 
1. sources weren't taken for evaluation - 
`setSources` after configure: evaluator needs the config.source but it didn't update cause `setSources` called after.
`setSources` before `configure`: `sourceSelected` called but `entryId` didn't configure yet.
2. plugin doesn't load correctly from `setMedia` -
plugin config passes throw after sources loaded and then the plugin won't load.
Solution: 
Pass sources config to evaluation so plugin and sources will be loaded correctly.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
