### PR TITLE
fix(FEC-11374): Live DVR starting to cast from beginning of the DVR instead of Live edge

### DIFF
--- a/src/common/cast/base-remote-player.js
+++ b/src/common/cast/base-remote-player.js
@@ -430,6 +430,17 @@ class BaseRemotePlayer extends FakeEventTarget implements IRemotePlayer {
   }
 
   /**
+   * @returns {number} - The live duration in seconds.
+   * @instance
+   * @memberof BaseRemotePlayer
+   * @example
+   * BaseRemotePlayer.prototype.liveDuration // NaN
+   */
+  get liveDuration(): number {
+    return NaN;
+  }
+
+  /**
    * Setter.
    * @param {number} vol - The volume to set in the range of 0-1.
    * @returns {void}

--- a/src/common/cast/remote-player.js
+++ b/src/common/cast/remote-player.js
@@ -53,6 +53,13 @@ export interface IRemotePlayer {
   +duration: number;
   /**
    * @readonly
+   * @type {number}
+   * @instance
+   * @memberof IRemotePlayer
+   */
+  +liveDuration: number;
+  /**
+   * @readonly
    * @type {boolean}
    * @instance
    * @memberof IRemotePlayer


### PR DESCRIPTION
### Description of the Changes

Add missing API in base remote player interface.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
