### PR TITLE
fix(FEC-11431): no preview thumbnails shown when casting on chromecast - regression

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,3 +15,4 @@ module.name_mapper='player-defaults' -> '<PROJECT_ROOT>/src/ovp/player-defaults'
 module.name_mapper='player-defaults' -> '<PROJECT_ROOT>/src/ott/player-defaults'
 module.name_mapper='poster' -> '<PROJECT_ROOT>/src/ovp/poster'
 module.name_mapper='poster' -> '<PROJECT_ROOT>/src/ott/poster'
+esproposal.optional_chaining=enable

--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -1,7 +1,6 @@
 // @flow
-import {Utils, ThumbnailInfo, MediaType, EventManager} from '@playkit-js/playkit-js';
+import {Utils, ThumbnailInfo, MediaType, EventManager, Html5EventType} from '@playkit-js/playkit-js';
 import evaluate from './utils/evaluate';
-import {Html5EventType} from '@playkit-js/playkit-js/dist/playkit';
 
 const DefaultThumbnailConfig: Object = {
   thumbsWidth: 164,

--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -1,6 +1,7 @@
 // @flow
-import {Utils, ThumbnailInfo, MediaType} from '@playkit-js/playkit-js';
+import {Utils, ThumbnailInfo, MediaType, EventManager} from '@playkit-js/playkit-js';
 import evaluate from './utils/evaluate';
+import {Html5EventType} from '@playkit-js/playkit-js/dist/playkit';
 
 const DefaultThumbnailConfig: Object = {
   thumbsWidth: 164,
@@ -14,10 +15,25 @@ const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth
 class ThumbnailManager {
   _player: Player;
   _thumbnailConfig: ?KPThumbnailConfig;
+  _eventManager: EventManager;
+  _origVideoHeight: number;
+  _origVideoWidth: number;
+  _origDuration: number;
 
   constructor(player: Player, uiConfig: KPUIOptionsObject, mediaConfig: KPMediaConfig) {
     this._player = player;
     this._thumbnailConfig = this._buildKalturaThumbnailConfig(uiConfig, mediaConfig);
+    this._eventManager = new EventManager();
+
+    this._eventManager.listenOnce(this._player, Html5EventType.LOADED_METADATA, () => {
+      this._origVideoHeight = this._player.videoHeight;
+      this._origVideoWidth = this._player.videoWidth;
+      this._origDuration = this._player.duration;
+    });
+  }
+
+  destroy() {
+    this._eventManager.destroy();
   }
 
   getThumbnail(time: number): ?ThumbnailInfo {
@@ -38,8 +54,10 @@ class ThumbnailManager {
   _convertKalturaThumbnailToThumbnailInfo = (time: number): ?ThumbnailInfo => {
     if (this._thumbnailConfig) {
       const {thumbsSprite, thumbsWidth, thumbsSlices} = this._thumbnailConfig;
-      const thumbsHeight = Math.floor(thumbsWidth * (this._player.videoHeight / this._player.videoWidth));
-      const duration = this._player.duration / thumbsSlices;
+      const videoHeight = this._player.videoHeight || this._origVideoHeight;
+      const videoWidth = this._player.videoWidth || this._origVideoWidth;
+      const thumbsHeight = Math.floor(thumbsWidth * (videoHeight / videoWidth));
+      const duration = (this._player.duration || this._origDuration) / thumbsSlices;
       const thumbnailInfo = {
         x: Math.floor(time / duration) * thumbsWidth,
         y: 0,

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -316,6 +316,7 @@ class KalturaPlayer extends FakeEventTarget {
       this._resetProviderPluginsConfig();
       this._pluginManager.reset();
       this._localPlayer.reset();
+      this._thumbnailManager.destroy();
     }
   }
 
@@ -329,6 +330,7 @@ class KalturaPlayer extends FakeEventTarget {
     this._playlistManager.destroy();
     this._localPlayer.destroy();
     this._eventManager.destroy();
+    this._thumbnailManager.destroy();
     this._viewabilityManager.destroy();
     RemotePlayerManager.destroy();
     this._pluginsConfig = {};

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -316,7 +316,7 @@ class KalturaPlayer extends FakeEventTarget {
       this._resetProviderPluginsConfig();
       this._pluginManager.reset();
       this._localPlayer.reset();
-      this._thumbnailManager.destroy();
+      this._thumbnailManager?.destroy();
     }
   }
 
@@ -330,7 +330,7 @@ class KalturaPlayer extends FakeEventTarget {
     this._playlistManager.destroy();
     this._localPlayer.destroy();
     this._eventManager.destroy();
-    this._thumbnailManager.destroy();
+    this._thumbnailManager?.destroy();
     this._viewabilityManager.destroy();
     RemotePlayerManager.destroy();
     this._pluginsConfig = {};

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -19,7 +19,9 @@ describe('ThumbnailManager', () => {
           }
         }
       },
-      getThumbnail: () => {}
+      getThumbnail: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {}
     };
     fakeMediaConfig = {
       sources: {


### PR DESCRIPTION
### Description of the Changes

When casting the player doesn't have the playing video to get the height and width. 
The solution is to keep the video height and width before the cast and use it as fallback.

Also found another bug - same issue with duration - caused the preview image to be stuck on first frame.
Solved same.

Solves FEC-11431

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
