### PR TITLE
fix(FEC-11431): refactor preview thumb height from real image sprite height

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -166,7 +166,7 @@ class KalturaPlayer extends FakeEventTarget {
       playerConfig.playback = playback;
     }
     if (!hasYoutubeSource(sources)) {
-      this._thumbnailManager = new ThumbnailManager(this._localPlayer, this.config.ui, mediaConfig);
+      this._thumbnailManager = new ThumbnailManager(this, this.config.ui, mediaConfig);
     }
     this.configure({...playerConfig, sources});
   }

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -20,8 +20,9 @@ describe('ThumbnailManager', () => {
         }
       },
       getThumbnail: () => {},
-      addEventListener: () => {},
-      removeEventListener: () => {}
+      _localPlayer: {
+        getThumbnail: () => {}
+      }
     };
     fakeMediaConfig = {
       sources: {
@@ -102,15 +103,13 @@ describe('ThumbnailManager', () => {
     spy.should.calledOnce;
   });
 
-  it('should return thumbnail height from core player with video ratio 4:3', () => {
+  it('should return thumbnail height from image sprite', () => {
     fakeMediaConfig.sources.poster = null;
     fakePlayer.config.ui.components.seekbar.thumbsSprite = thumbsSprite;
     thumbnailManager = new ThumbnailManager(fakePlayer, fakePlayer.config.ui, fakeMediaConfig);
-    fakePlayer.duration = 1000;
-    fakePlayer.videoHeight = 480;
-    fakePlayer.videoWidth = 640;
+    thumbnailManager._thumbsHeight = 999;
     const thumbInfo = thumbnailManager.getThumbnail(100);
-    thumbInfo.height.should.equal(thumbInfo.width * (fakePlayer.videoHeight / fakePlayer.videoWidth));
+    thumbInfo.height.should.equal(999);
   });
 
   it('should set the configured thumbs sprite with default sizes', () => {

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -98,7 +98,7 @@ describe('ThumbnailManager', () => {
   it('should return thumbnail from core player', () => {
     fakeMediaConfig.sources.poster = null;
     thumbnailManager = new ThumbnailManager(fakePlayer, fakePlayer.config.ui, fakeMediaConfig);
-    const spy = sandbox.spy(fakePlayer, 'getThumbnail');
+    const spy = sandbox.spy(fakePlayer._localPlayer, 'getThumbnail');
     thumbnailManager.getThumbnail(100);
     spy.should.calledOnce;
   });


### PR DESCRIPTION
### Description of the Changes

Following https://github.com/kaltura/kaltura-player-js/pull/466, https://github.com/kaltura/kaltura-player-js/pull/471, https://github.com/kaltura/kaltura-player-js/pull/472 - code was refactored so image thumb height is taken from real image sprite. This overrides all issues regarding height miscalculations and the need for videoHeight (which is missing when casting) 
In addition kaltura player was passed to ThumbsManager instead of core player to fix preview image when casting as the duration when casting needs to come from cast player and not the core one.

Solves FEC-11431

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [X] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
