### PR TITLE
fix(FEC-11513): Need to click the Retry button twice after error

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,6 +25,7 @@ module.exports = config => {
     colors: true,
     frameworks: ['mocha'],
     files: [
+      'node_modules/regenerator-runtime/runtime.js',
       'test/setup/karma.js',
       {
         pattern: 'test/assets/mov_bbb.mp4',

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -121,6 +121,7 @@ class KalturaPlayer extends FakeEventTarget {
    * kalturaPlayer.loadMedia({entryId: 'entry123'}, {startTime: 5, poster: 'my/poster/url'});
    */
   loadMedia(mediaInfo: ProviderMediaInfoObject, mediaOptions?: PKSourcesConfigObject): Promise<*> {
+    this._reset = false;
     KalturaPlayer._logger.debug('loadMedia', mediaInfo);
     this._mediaInfo = mediaInfo;
     this.reset();

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -108,9 +108,6 @@ class KalturaPlayer extends FakeEventTarget {
     //configure sources after configure finished for all components - making sure all we'll set up correctly
     this._playlistManager.configure({items: (options.playlist && options.playlist.items) || []});
     this._localPlayer.setSources(sources || {});
-    this._eventManager.listen(this, CoreEventType.ERROR, () => {
-      this._reset = false;
-    });
   }
 
   /**
@@ -742,6 +739,11 @@ class KalturaPlayer extends FakeEventTarget {
         }
       });
     }
+    this._eventManager.listen(this, CoreEventType.ERROR, (event: FakeEvent) => {
+      if (event.payload.severity === Error.Severity.CRITICAL) {
+        this._reset = false;
+      }
+    });
   }
 
   _onChangeSourceEnded(): void {

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -108,6 +108,9 @@ class KalturaPlayer extends FakeEventTarget {
     //configure sources after configure finished for all components - making sure all we'll set up correctly
     this._playlistManager.configure({items: (options.playlist && options.playlist.items) || []});
     this._localPlayer.setSources(sources || {});
+    this._eventManager.listen(this, CoreEventType.ERROR, () => {
+      this._reset = false;
+    });
   }
 
   /**
@@ -121,7 +124,6 @@ class KalturaPlayer extends FakeEventTarget {
    * kalturaPlayer.loadMedia({entryId: 'entry123'}, {startTime: 5, poster: 'my/poster/url'});
    */
   loadMedia(mediaInfo: ProviderMediaInfoObject, mediaOptions?: PKSourcesConfigObject): Promise<*> {
-    this._reset = false;
     KalturaPlayer._logger.debug('loadMedia', mediaInfo);
     this._mediaInfo = mediaInfo;
     this.reset();

--- a/test/src/kaltura-player.spec.js
+++ b/test/src/kaltura-player.spec.js
@@ -113,6 +113,14 @@ describe('kaltura player api', function () {
         kalturaPlayer.loadMedia({entryId}, {poster});
       });
 
+      it('the reset stat should be false whenever an error occurs', function (done) {
+        kalturaPlayer._reset.should.be.true;
+        kalturaPlayer.loadMedia({}).catch(() => {
+          kalturaPlayer._reset.should.be.false;
+          done();
+        });
+      });
+
       describe('maybeSetStreamPriority', function () {
         describe('media source mime type is video/youtube', function () {
           it('should add youtube to stream priority if not already set', function (done) {


### PR DESCRIPTION
### Description of the Changes
Issue :the reset logic is not called in the first press since the _reset stat flag is true 
fix: rest the _reset state to false every time  error occur by listening to all error events dispatched from the player
Resolve FEC-11513

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
