### PR TITLE
fix(FEC-11510): No default font size selected in cvaa

### DIFF
--- a/test/src/setup.spec.js
+++ b/test/src/setup.spec.js
@@ -2,6 +2,7 @@ import '../../src/index';
 import {setup} from '../../src/setup';
 import * as TestUtils from './utils/test-utils';
 import StorageWrapper from '../../src/common/storage/storage-wrapper';
+import {TextStyle} from '@playkit-js/playkit-js';
 
 const targetId = 'player-placeholder_setup.spec';
 
@@ -69,20 +70,18 @@ describe('setup', function () {
   });
 
   it('should set text style from storage', function () {
-    let textStyle = {
-      fontSize: '20%',
+    let textStyle = TextStyle.fromJson({
+      fontSize: '75%',
       fontFamily: 'sans-serif',
       fontColor: [14, 15, 0],
       fontOpacity: 0,
       backgroundColor: [1, 2, 3],
       backgroundOpacity: 1,
-      fontEdge: [],
-      fontScale: 1
-    };
+      fontEdge: []
+    });
     sandbox.stub(StorageWrapper, 'getItem').withArgs('textStyle').returns(textStyle);
     kalturaPlayer = setup(config);
-    const textStyleObj = JSON.parse(JSON.stringify(kalturaPlayer.textStyle));
-    textStyleObj.should.deep.equal(textStyle);
+    kalturaPlayer.textStyle.should.deep.equal(textStyle);
   });
 
   it('should configure sources', function (done) {


### PR DESCRIPTION
### Description of the Changes

Remove references to fontScale to match changes in playkit-js.
Fixes FEC-11510.

Related PRs:
https://github.com/kaltura/playkit-js/pull/603
https://github.com/kaltura/playkit-js-ui/pull/639

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
