### PR TITLE
docs(FEC-11547): The thumbnalils images should be relative to the VTT file adress by default

### DIFF
--- a/docs/adding-vtt-thumbnails.md
+++ b/docs/adding-vtt-thumbnails.md
@@ -5,9 +5,8 @@ Kaltura player supports the loading of preview thumbnails using VTT files,
 #### A configuration for the VTT file is provided as a part of the mediaOptions or mediaConfig objects parameters As seen in the examples, we include:
 
 - vttUrl: URL to the WebVTT file that refers to the thumbnails.
-- imgBaseUrl (optional): the base image url where the images / sprite image are served from.
 
-NOTE: The URL is relative to the application domain by default
+NOTE: The urls specified in the WebVTT file are relative to the vtt file address.
 
 ### exemple 1 - provided as a part of the mediaOptions
 
@@ -17,8 +16,7 @@ kalturaPlayer.loadMedia(
   {entryId: '0_wifqaipd'},
   {
     thumbnails: {
-      vttUrl: 'https://www.radiantmediaplayer.com/media/vtt/thumbnails/bbb-thumbnails.vtt',
-      imgBaseUrl: 'https://www.radiantmediaplayer.com/media/vtt/thumbnails'
+      vttUrl: 'https://www.radiantmediaplayer.com/media/vtt/thumbnails/bbb-thumbnails.vtt'
     }
   }
 );
@@ -34,7 +32,6 @@ kalturaPlayer.setMedia({
     options: {},
     thumbnails : {
       vttUrl: 'https://www.radiantmediaplayer.com/media/vtt/thumbnails/bbb-thumbnails.vtt',
-      imgBaseUrl:'https://www.radiantmediaplayer.com/media/vtt/thumbnails'
     }
   }
 });

--- a/docs/adding-vtt-thumbnails.md
+++ b/docs/adding-vtt-thumbnails.md
@@ -16,7 +16,7 @@ kalturaPlayer.loadMedia(
   {entryId: '0_wifqaipd'},
   {
     thumbnails: {
-      vttUrl: 'https://www.radiantmediaplayer.com/media/vtt/thumbnails/bbb-thumbnails.vtt'
+      vttUrl: 'https://somedomain/media/thumbnails/thumbnails.vtt'
     }
   }
 );
@@ -31,7 +31,7 @@ kalturaPlayer.setMedia({
   sources: {
     options: {},
     thumbnails : {
-      vttUrl: 'https://www.radiantmediaplayer.com/media/vtt/thumbnails/bbb-thumbnails.vtt',
+      vttUrl: 'https://somedomain/media/thumbnails/thumbnails.vtt',
     }
   }
 });


### PR DESCRIPTION
### Description of the Changes

update docs

solves: FEC-11547

related pr: https://github.com/kaltura/playkit-js/pull/607

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
