### PR TITLE
feat(FEC-11554): delay addCuePoints after media loaded in video

### DIFF
--- a/src/common/cuepoint/cuepoint-manager.js
+++ b/src/common/cuepoint/cuepoint-manager.js
@@ -38,6 +38,10 @@ export class CuePointManager {
     return this._textTrack?.cues || [];
   }
 
+  getActiveCuePoints() {
+    return this._textTrack?.activeCues || [];
+  }
+
   getCuePointById(id: string) {
     return this._textTrack?.cues?.getCueById(id);
   }
@@ -47,21 +51,23 @@ export class CuePointManager {
   }
 
   addCuePoints(data: CuePoint[]) {
-    if (!this._textTrack) {
-      this._addTextTrack();
-    }
-    const newCuePoints: window.VTTCue | typeof Cue = [];
-
-    data.forEach((cuePoint: CuePoint) => {
-      const textTrackCue = this._createTextTrackCue(cuePoint);
-      const exisedCue = this.getCuePointById(textTrackCue.id);
-      if (exisedCue) {
-        this.removeCuePoint(exisedCue);
+    this._player.ready().then(() => {
+      if (!this._textTrack) {
+        this._addTextTrack();
       }
-      this._textTrack?.addCue(textTrackCue);
-      newCuePoints.push(textTrackCue);
+      const newCuePoints: window.VTTCue | typeof Cue = [];
+
+      data.forEach((cuePoint: CuePoint) => {
+        const textTrackCue = this._createTextTrackCue(cuePoint);
+        const exisedCue = this.getCuePointById(textTrackCue.id);
+        if (exisedCue) {
+          this.removeCuePoint(exisedCue);
+        }
+        this._textTrack?.addCue(textTrackCue);
+        newCuePoints.push(textTrackCue);
+      });
+      this._player.dispatchEvent(new FakeEvent(EventType.TIMED_METADATA_ADDED, {cues: newCuePoints}));
     });
-    this._player.dispatchEvent(new FakeEvent(EventType.TIMED_METADATA_ADDED, {cues: newCuePoints}));
   }
 
   clearAllCuePoints() {

--- a/test/src/common/cuepoints/cuepoint-manager.spec.js
+++ b/test/src/common/cuepoints/cuepoint-manager.spec.js
@@ -29,7 +29,9 @@ describe('CuePointManager', () => {
     player.setMedia({sources: SourcesConfig.Mp4});
     expect(player.cuePointManager._textTrack).to.eql(null);
     player.cuePointManager.addCuePoints([]);
-    expect(player.cuePointManager._textTrack).instanceOf(TextTrack);
+    player.ready().then(() => {
+      expect(player.cuePointManager._textTrack).instanceOf(TextTrack);
+    });
   });
 
   it('should add/get/remove/clear-all cue points', function () {
@@ -51,14 +53,16 @@ describe('CuePointManager', () => {
       }
     ];
     player.setMedia({sources: SourcesConfig.Mp4});
-    expect(player.cuePointManager.getAllCuePoints().length).eql(0);
-    player.cuePointManager.addCuePoints(cuePoints);
-    expect(player.cuePointManager.getAllCuePoints().length).eql(3);
-    const cuePoint = player.cuePointManager.getCuePointById('test-id-1');
-    expect(cuePoint.id).to.eql('test-id-1');
-    player.cuePointManager.removeCuePoint(cuePoint);
-    expect(player.cuePointManager.getAllCuePoints().length).eql(2);
-    player.cuePointManager.clearAllCuePoints();
-    expect(player.cuePointManager.getAllCuePoints().length).eql(0);
+    player.ready().then(() => {
+      expect(player.cuePointManager.getAllCuePoints().length).eql(0);
+      player.cuePointManager.addCuePoints(cuePoints);
+      expect(player.cuePointManager.getAllCuePoints().length).eql(3);
+      const cuePoint = player.cuePointManager.getCuePointById('test-id-1');
+      expect(cuePoint.id).to.eql('test-id-1');
+      player.cuePointManager.removeCuePoint(cuePoint);
+      expect(player.cuePointManager.getAllCuePoints().length).eql(2);
+      player.cuePointManager.clearAllCuePoints();
+      expect(player.cuePointManager.getAllCuePoints().length).eql(0);
+    });
   });
 });


### PR DESCRIPTION
### Description of the Changes

following https://kaltura.atlassian.net/browse/FEV-993
When adding cue points to video element text track, if they are added before video is loaded to video tag then the cues are cleared. Need to wait for player.ready()

Also added new api in cuepoint manager - getActiveCuePoints()

Solves FEC-11554

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
