### PR TITLE
fix(FEC-11695,FEC-11698): player thumbnail stripe URL changes according to player size

### DIFF
--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -79,7 +79,7 @@ class ThumbnailManager {
   };
 
   _getPosterUrl(mediaConfig: KPMediaConfig): ?string {
-    if (mediaConfig.sources && typeof mediaConfig.sources.poster === 'string') {
+    if (mediaConfig.sources && mediaConfig.sources.poster) {
       let posterUrl = mediaConfig.sources.poster;
       if (DIMENSIONS_REGEX.test(posterUrl)) {
         posterUrl = posterUrl.replace(DIMENSIONS_REGEX, '');
@@ -88,7 +88,7 @@ class ThumbnailManager {
     }
   }
 
-  _getThumbSlicesUrl = (posterUrl: ?string | Array<Object>, ks: ?string, thumbnailConfig: Object): string => {
+  _getThumbSlicesUrl = (posterUrl: string | Array<Object>, ks: ?string, thumbnailConfig: Object): string => {
     if (typeof posterUrl === 'string') {
       if (THUMBNAIL_REGEX.test(posterUrl)) {
         try {

--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -9,7 +9,6 @@ const DefaultThumbnailConfig: Object = {
 };
 
 const THUMBNAIL_REGEX = /.*\/p\/\d+\/(?:[a-zA-Z]+\/\d+\/)*thumbnail\/entry_id\/\w+\/.*\d+/;
-const DIMENSIONS_REGEX = /\/height\/[0-9]+\/width\/[0-9]+$/;
 const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth}}/vid_slices/{{thumbsSlices}}/ks/{{ks}}';
 
 class ThumbnailManager {
@@ -67,7 +66,7 @@ class ThumbnailManager {
 
   _buildKalturaThumbnailConfig = (uiConfig: KPUIOptionsObject, mediaConfig: KPMediaConfig): ?KPThumbnailConfig => {
     const seekbarConfig = Utils.Object.getPropertyPath(uiConfig, 'components.seekbar');
-    const posterUrl = this._getPosterUrl(mediaConfig);
+    const posterUrl = mediaConfig.sources && mediaConfig.sources.poster;
     const isVod = mediaConfig.sources && mediaConfig.sources.type === MediaType.VOD;
     const ks = mediaConfig.session && mediaConfig.session.ks;
     const thumbnailConfig = Utils.Object.mergeDeep(DefaultThumbnailConfig, seekbarConfig);
@@ -77,16 +76,6 @@ class ThumbnailManager {
       ...thumbnailConfig
     };
   };
-
-  _getPosterUrl(mediaConfig: KPMediaConfig): ?string {
-    if (mediaConfig.sources && mediaConfig.sources.poster) {
-      let posterUrl = mediaConfig.sources.poster;
-      if (DIMENSIONS_REGEX.test(posterUrl)) {
-        posterUrl = posterUrl.replace(DIMENSIONS_REGEX, '');
-      }
-      return posterUrl;
-    }
-  }
 
   _getThumbSlicesUrl = (posterUrl: string | Array<Object>, ks: ?string, thumbnailConfig: Object): string => {
     if (typeof posterUrl === 'string') {
@@ -107,4 +96,4 @@ class ThumbnailManager {
   };
 }
 
-export {ThumbnailManager, THUMBNAIL_REGEX, DIMENSIONS_REGEX, DefaultThumbnailConfig};
+export {ThumbnailManager, THUMBNAIL_REGEX, DefaultThumbnailConfig};

--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -79,7 +79,7 @@ class ThumbnailManager {
   };
 
   _getPosterUrl(mediaConfig: KPMediaConfig): ?string {
-    if (mediaConfig.sources && mediaConfig.sources.poster) {
+    if (mediaConfig.sources && typeof mediaConfig.sources.poster === 'string') {
       let posterUrl = mediaConfig.sources.poster;
       if (DIMENSIONS_REGEX.test(posterUrl)) {
         posterUrl = posterUrl.replace(DIMENSIONS_REGEX, '');
@@ -88,7 +88,7 @@ class ThumbnailManager {
     }
   }
 
-  _getThumbSlicesUrl = (posterUrl: string | Array<Object>, ks: ?string, thumbnailConfig: Object): string => {
+  _getThumbSlicesUrl = (posterUrl: ?string | Array<Object>, ks: ?string, thumbnailConfig: Object): string => {
     if (typeof posterUrl === 'string') {
       if (THUMBNAIL_REGEX.test(posterUrl)) {
         try {

--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -9,6 +9,7 @@ const DefaultThumbnailConfig: Object = {
 };
 
 const THUMBNAIL_REGEX = /.*\/p\/\d+\/(?:[a-zA-Z]+\/\d+\/)*thumbnail\/entry_id\/\w+\/.*\d+/;
+const DIMENSIONS_REGEX = /\/height\/[0-9]+\/width\/[0-9]+$/;
 const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth}}/vid_slices/{{thumbsSlices}}/ks/{{ks}}';
 
 class ThumbnailManager {
@@ -66,7 +67,7 @@ class ThumbnailManager {
 
   _buildKalturaThumbnailConfig = (uiConfig: KPUIOptionsObject, mediaConfig: KPMediaConfig): ?KPThumbnailConfig => {
     const seekbarConfig = Utils.Object.getPropertyPath(uiConfig, 'components.seekbar');
-    const posterUrl = mediaConfig.sources && mediaConfig.sources.poster;
+    const posterUrl = this._getPosterUrl(mediaConfig);
     const isVod = mediaConfig.sources && mediaConfig.sources.type === MediaType.VOD;
     const ks = mediaConfig.session && mediaConfig.session.ks;
     const thumbnailConfig = Utils.Object.mergeDeep(DefaultThumbnailConfig, seekbarConfig);
@@ -76,6 +77,16 @@ class ThumbnailManager {
       ...thumbnailConfig
     };
   };
+
+  _getPosterUrl(mediaConfig: KPMediaConfig): ?string {
+    if (mediaConfig.sources && mediaConfig.sources.poster) {
+      let posterUrl = mediaConfig.sources.poster;
+      if (DIMENSIONS_REGEX.test(posterUrl)) {
+        posterUrl = posterUrl.replace(DIMENSIONS_REGEX, '');
+      }
+      return posterUrl;
+    }
+  }
 
   _getThumbSlicesUrl = (posterUrl: string | Array<Object>, ks: ?string, thumbnailConfig: Object): string => {
     if (typeof posterUrl === 'string') {
@@ -96,4 +107,4 @@ class ThumbnailManager {
   };
 }
 
-export {ThumbnailManager, THUMBNAIL_REGEX, DefaultThumbnailConfig};
+export {ThumbnailManager, THUMBNAIL_REGEX, DIMENSIONS_REGEX, DefaultThumbnailConfig};

--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -165,14 +165,14 @@ class KalturaPlayer extends FakeEventTarget {
     Object.keys(this._pluginsConfig).forEach(name => {
       playerConfig.plugins[name] = playerConfig.plugins[name] || {};
     });
+    if (!hasYoutubeSource(sources)) {
+      this._thumbnailManager = new ThumbnailManager(this, this.config.ui, mediaConfig);
+    }
     addKalturaPoster(sources, mediaConfig.sources, this._localPlayer.dimensions);
     addKalturaParams(this, {...playerConfig, sources});
     const playback = maybeSetStreamPriority(this, sources);
     if (playback) {
       playerConfig.playback = playback;
-    }
-    if (!hasYoutubeSource(sources)) {
-      this._thumbnailManager = new ThumbnailManager(this, this.config.ui, mediaConfig);
     }
     this.configure({...playerConfig, sources});
   }

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -1,5 +1,5 @@
 import {MediaType} from '@playkit-js/playkit-js';
-import {DefaultThumbnailConfig, ThumbnailManager, DIMENSIONS_REGEX} from '../../../src/common/thumbnail-manager';
+import {DefaultThumbnailConfig, ThumbnailManager} from '../../../src/common/thumbnail-manager';
 
 describe('ThumbnailManager', () => {
   let thumbnailManager, fakePlayer, fakeMediaConfig, sandbox;
@@ -26,7 +26,7 @@ describe('ThumbnailManager', () => {
     };
     fakeMediaConfig = {
       sources: {
-        poster: '//my-thumb-service.com/p/1/thumbnail/entry_id/2/version/3/height/300/width/600',
+        poster: '//my-thumb-service.com/p/1/thumbnail/entry_id/2/version/3',
         type: MediaType.VOD
       },
       session: {
@@ -44,9 +44,7 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster.replace(DIMENSIONS_REGEX, '')}/width/${DefaultThumbnailConfig.thumbsWidth}/vid_slices/${
-          DefaultThumbnailConfig.thumbsSlices
-        }/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster}/width/${DefaultThumbnailConfig.thumbsWidth}/vid_slices/${DefaultThumbnailConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
       );
   });
 
@@ -62,9 +60,7 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster.replace(DIMENSIONS_REGEX, '')}/width/${fakeSeekbarConfig.thumbsWidth}/vid_slices/${
-          fakeSeekbarConfig.thumbsSlices
-        }/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster}/width/${fakeSeekbarConfig.thumbsWidth}/vid_slices/${fakeSeekbarConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
       );
   });
 

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -1,5 +1,5 @@
 import {MediaType} from '@playkit-js/playkit-js';
-import {DefaultThumbnailConfig, ThumbnailManager} from '../../../src/common/thumbnail-manager';
+import {DefaultThumbnailConfig, ThumbnailManager, DIMENSIONS_REGEX} from '../../../src/common/thumbnail-manager';
 
 describe('ThumbnailManager', () => {
   let thumbnailManager, fakePlayer, fakeMediaConfig, sandbox;
@@ -26,7 +26,7 @@ describe('ThumbnailManager', () => {
     };
     fakeMediaConfig = {
       sources: {
-        poster: '//my-thumb-service.com/p/1/thumbnail/entry_id/2/version/3',
+        poster: '//my-thumb-service.com/p/1/thumbnail/entry_id/2/version/3/height/300/width/600',
         type: MediaType.VOD
       },
       session: {
@@ -44,7 +44,9 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster}/width/${DefaultThumbnailConfig.thumbsWidth}/vid_slices/${DefaultThumbnailConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster.replace(DIMENSIONS_REGEX, '')}/width/${DefaultThumbnailConfig.thumbsWidth}/vid_slices/${
+          DefaultThumbnailConfig.thumbsSlices
+        }/ks/${fakeMediaConfig.session.ks}`
       );
   });
 
@@ -60,7 +62,9 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster}/width/${fakeSeekbarConfig.thumbsWidth}/vid_slices/${fakeSeekbarConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster.replace(DIMENSIONS_REGEX, '')}/width/${fakeSeekbarConfig.thumbsWidth}/vid_slices/${
+          fakeSeekbarConfig.thumbsSlices
+        }/ks/${fakeMediaConfig.session.ks}`
       );
   });
 

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -1,5 +1,7 @@
 import {MediaType} from '@playkit-js/playkit-js';
 import {DefaultThumbnailConfig, ThumbnailManager} from '../../../src/common/thumbnail-manager';
+import * as TestUtils from '../utils/test-utils';
+import {setup} from '../../../src';
 
 describe('ThumbnailManager', () => {
   let thumbnailManager, fakePlayer, fakeMediaConfig, sandbox;
@@ -148,5 +150,55 @@ describe('ThumbnailManager', () => {
     const config = thumbnailManager.getKalturaThumbnailConfig();
     config.thumbsSlices.should.equal(200);
     config.thumbsWidth.should.equal(300);
+  });
+
+  describe('Poster Integration', function () {
+    const targetId = 'player-placeholder_ovp/thumbnail.spec';
+
+    let config, kalturaPlayer;
+    const myCustomPosterUrl = 'https://www.elastic.co/assets/bltada7771f270d08f6/enhanced-buzz-1492-1379411828-15.jpg';
+    const entryId = '0_wifqaipd';
+    const partnerId = 1091;
+    const env = {
+      cdnUrl: 'http://qa-apache-php7.dev.kaltura.com/',
+      serviceUrl: 'http://qa-apache-php7.dev.kaltura.com/api_v3'
+    };
+
+    before(function () {
+      TestUtils.createElement('DIV', targetId);
+    });
+
+    beforeEach(function () {
+      config = {
+        targetId: targetId,
+        provider: {
+          partnerId: partnerId,
+          env: env
+        },
+        sources: {}
+      };
+    });
+
+    afterEach(function () {
+      kalturaPlayer.destroy();
+      TestUtils.removeVideoElementsFromTestPage();
+    });
+
+    after(function () {
+      TestUtils.removeElement(targetId);
+    });
+
+    it('should create thumbnail url from provider poster not from configured poster', function (done) {
+      config.sources.poster = myCustomPosterUrl;
+      kalturaPlayer = setup(config);
+      kalturaPlayer.loadMedia({entryId: entryId}).then(() => {
+        try {
+          kalturaPlayer.getThumbnail().should.be.exist;
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
### Description of the Changes

build the thumbnail url from provider response before the poster manipulation

Solves FEC-11695, FEC-11698

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
