### PR TITLE
fix(FEC-11711): loadMedia is triggered before configuration is set from getMediaConfig

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -287,10 +287,13 @@ class KalturaPlayer extends FakeEventTarget {
     const localPlayerConfig = Utils.Object.mergeDeep({}, config);
     delete localPlayerConfig.plugins;
     if (localPlayerConfig.sources) {
-      this._localPlayer.setSources(localPlayerConfig.sources || {});
+      const {sources} = localPlayerConfig;
       delete localPlayerConfig.sources;
+      this._localPlayer.configure(localPlayerConfig);
+      this._localPlayer.setSources(sources || {});
+    } else {
+      this._localPlayer.configure(localPlayerConfig);
     }
-    this._localPlayer.configure(localPlayerConfig);
     const uiConfig = config.ui;
     if (uiConfig) {
       this._uiWrapper.setConfig(configDictionary.ui);


### PR DESCRIPTION
### Description of the Changes

move `setSources` after `configure`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
