### PR TITLE
fix(FEC-9716): An array doesn't merged into plugin config

### DIFF
--- a/src/common/plugins/plugins-config.js
+++ b/src/common/plugins/plugins-config.js
@@ -30,7 +30,18 @@ const removeUnevaluatedExpression = (obj: Object = {}): Object =>
     if (Utils.Object.isObject(value) && typeof value !== 'function' && !Utils.Object.isClassInstance(value)) {
       product[key] = removeUnevaluatedExpression(value);
     } else if (Array.isArray(value)) {
-      product[key] = value.filter(index => isValueEvaluated(index));
+      product[key] = value
+        .map(item => {
+          if (Utils.Object.isObject(item) && typeof item !== 'function' && !Utils.Object.isClassInstance(item)) {
+            const updatedItem = removeUnevaluatedExpression(item);
+            return Utils.Object.isEmptyObject(updatedItem) ? null : updatedItem;
+          } else if (isValueEvaluated(item)) {
+            return item;
+          } else {
+            return null;
+          }
+        })
+        .filter(item => item !== null);
     } else if (isValueEvaluated(value)) {
       product[key] = value;
     }


### PR DESCRIPTION
### Description of the Changes

If an array in plugin config contains an object item, call removeUnevaluatedExpression on it instead of filtering it out

Resolves FEC-9716

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
