### PR TITLE
fix(FEC-12000): smart tv - dash video not working

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -406,7 +406,7 @@ function _configureLGSDK2HlsLiveConfig(options: KPOptionsObject): void {
 }
 
 /**
- * Sets config option for LG TV
+ * Sets config option for smart TV
  * @private
  * @param {KPOptionsObject} options - kaltura player options
  * @returns {void}
@@ -433,6 +433,10 @@ function configureSmartTVDefaultOptions(options: KPOptionsObject): void {
       if (typeof playheadMonitorInterval !== 'number') {
         options = Utils.Object.createPropertyPath(options, 'plugins.youbora.playheadMonitorInterval', 2000);
       }
+    }
+    const lowLatencyMode = Utils.Object.getPropertyPath(options, 'streaming.lowLatencyMode');
+    if (typeof lowLatencyMode !== 'boolean') {
+      options = Utils.Object.createPropertyPath(options, 'streaming.lowLatencyMode', false);
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

set `lowLatencyMode` to false by default in smart TV's

Solves FEC-12000

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
