### PR TITLE
fix(FEC-12059): [Youbora] Rendition values have a high number of "Undefined data" records

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -635,6 +635,14 @@ class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.src;
   }
 
+  get videoHeight(): ?number {
+    return this._localPlayer.videoHeight;
+  }
+
+  get videoWidth(): ?number {
+    return this._localPlayer.videoWidth;
+  }
+
   set dimensions(dimensions?: PKPlayerDimensions) {
     this._localPlayer.dimensions = dimensions;
   }


### PR DESCRIPTION
### Description of the Changes

issue: Safari doesn’t expose the videoTrack.height/width/bandwidth so youbora doesn;t send the rendition
fix: Expose the element.videoHeight and element.videoWidth (from the playkit)

solves:  FEC-12059

related pr: https://github.com/kaltura/playkit-js-youbora/pull/90

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
