### PR TITLE
feat(FEC-12229): append KS in provider to thumbnail API

### DIFF
--- a/src/common/thumbnail-manager.js
+++ b/src/common/thumbnail-manager.js
@@ -9,7 +9,7 @@ const DefaultThumbnailConfig: Object = {
 };
 
 const THUMBNAIL_REGEX = /.*\/p\/\d+\/(?:[a-zA-Z]+\/\d+\/)*thumbnail\/entry_id\/\w+\/.*\d+/;
-const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth}}/vid_slices/{{thumbsSlices}}/ks/{{ks}}';
+const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth}}/vid_slices/{{thumbsSlices}}';
 
 class ThumbnailManager {
   _player: KalturaPlayer;
@@ -68,22 +68,20 @@ class ThumbnailManager {
     const seekbarConfig = Utils.Object.getPropertyPath(uiConfig, 'components.seekbar');
     const posterUrl = mediaConfig.sources && mediaConfig.sources.poster;
     const isVod = mediaConfig.sources && mediaConfig.sources.type === MediaType.VOD;
-    const ks = mediaConfig.session && mediaConfig.session.ks;
     const thumbnailConfig = Utils.Object.mergeDeep(DefaultThumbnailConfig, seekbarConfig);
-    const thumbsSprite = isVod ? this._getThumbSlicesUrl(posterUrl, ks, thumbnailConfig) : '';
+    const thumbsSprite = isVod ? this._getThumbSlicesUrl(posterUrl, thumbnailConfig) : '';
     return {
       thumbsSprite,
       ...thumbnailConfig
     };
   };
 
-  _getThumbSlicesUrl = (posterUrl: string | Array<Object>, ks: ?string, thumbnailConfig: Object): string => {
+  _getThumbSlicesUrl = (posterUrl: string | Array<Object>, thumbnailConfig: Object): string => {
     if (typeof posterUrl === 'string') {
       if (THUMBNAIL_REGEX.test(posterUrl)) {
         try {
           const model: Object = {
             thumbnailUrl: posterUrl,
-            ks,
             ...thumbnailConfig
           };
           return evaluate(THUMBNAIL_SERVICE_TEMPLATE, model);

--- a/test/src/common/thumbnail-manager.spec.js
+++ b/test/src/common/thumbnail-manager.spec.js
@@ -47,7 +47,7 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster}/width/${DefaultThumbnailConfig.thumbsWidth}/vid_slices/${DefaultThumbnailConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster}/width/${DefaultThumbnailConfig.thumbsWidth}/vid_slices/${DefaultThumbnailConfig.thumbsSlices}`
       );
   });
 
@@ -63,7 +63,7 @@ describe('ThumbnailManager', () => {
     thumbnailManager
       .getKalturaThumbnailConfig()
       .thumbsSprite.should.equals(
-        `${fakeMediaConfig.sources.poster}/width/${fakeSeekbarConfig.thumbsWidth}/vid_slices/${fakeSeekbarConfig.thumbsSlices}/ks/${fakeMediaConfig.session.ks}`
+        `${fakeMediaConfig.sources.poster}/width/${fakeSeekbarConfig.thumbsWidth}/vid_slices/${fakeSeekbarConfig.thumbsSlices}`
       );
   });
 


### PR DESCRIPTION
### Description of the Changes

- removing handling ks from _buildKalturaThumbnailConfig
- ks will not be added to thumbnail api by default, but only if needed- according to new configuration defined in provider.
- ks will never be added to thumbnail api when user is anonymous

doing a change where appending KS to thumbnail API inside provider, hence, _buildKalturaThumbnailConfig already gets the url with the ks inside (if it was needed) and no longer needs to deal with ks.

Solves FEC-12229

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
