### PR TITLE
fest(FEC-12873): upgrade hls.js library to v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@playkit-js/playkit-js-hls": "1.31.2",
     "@playkit-js/playkit-js-ui": "0.73.0",
     "@types/preact-i18n": "^2.3.1",
-    "hls.js": "1.2.8",
+    "hls.js": "1.3.1",
     "intersection-observer": "^0.12.0",
     "playkit-js-providers": "https://github.com/kaltura/playkit-js-providers.git#v2.37.0",
     "proxy-polyfill": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5009,10 +5009,10 @@ highlight.js@^9.15.5:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
 
-hls.js@1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.2.8.tgz#684e2f4007ad7747f74e8edce2434fc2f26e470f"
-  integrity sha512-vH4b0ATbMEQz7776YBt6kKlRlvuT7RiFfliuxzn6nBlksrEl5HfQxN1Fn5VUNVVt8rws1rKWzpWwXANgCm03rw==
+hls.js@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.3.1.tgz#2e43949aeaee8f3d54cabd7c4c1a9a718a03e7c2"
+  integrity sha512-6f4Qyrfj9sNUWMzNFKruqeD2KdisOwQ1GQJqnWAgMQ1hequlFK7e2dmF9qQD3mF/RI76hvztCMBptlPb+HcDow==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description of the Changes

upgrade hls.js v1.3.1
FEC-12873

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
