### PR TITLE
fix(FEC-12895): fix image player thumbnail logic

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -180,7 +180,7 @@ class KalturaPlayer extends FakeEventTarget {
       playerConfig.plugins[name] = playerConfig.plugins[name] || {};
     });
     this.configure({session: mediaConfig.session});
-    if (!hasYoutubeSource(sources) || !hasImageSource(sources)) {
+    if (!hasYoutubeSource(sources) && !hasImageSource(sources)) {
       this._thumbnailManager = new ThumbnailManager(this, this.config.ui, mediaConfig);
     } else {
       this._thumbnailManager = null;


### PR DESCRIPTION
prevent youtube to use thumbnail manager

FEC-12895

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
