### PR TITLE
fix(Sup:37514):Player V7 - Playlist side panel does not open for Live entries

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -173,7 +173,7 @@ class KalturaPlayer extends FakeEventTarget {
     this.reset(true);
     const playerConfig = Utils.Object.copyDeep(mediaConfig);
     //merge the current sources from player to keep the sources passed from constructor earlier
-    const sources = Utils.Object.mergeDeep({}, playerConfig.sources, this._localPlayer.sources);
+    const sources = Utils.Object.mergeDeep({}, this._localPlayer.sources, playerConfig.sources);
     delete playerConfig.sources;
     Utils.Object.mergeDeep(playerConfig.session, this._localPlayer.config.session);
     playerConfig.plugins = playerConfig.plugins || {};


### PR DESCRIPTION
issue:
recordings for live in playlist take the live entry and not the recording entry

solution:
change merge deep to prefer to take the entry id returns from the server instead of the entry id saved in the playlist
