### PR TITLE
fix(FEC-13241): use medias source data instead of playlist

### DIFF
--- a/src/common/playlist/playlist-manager.js
+++ b/src/common/playlist/playlist-manager.js
@@ -232,6 +232,10 @@ class PlaylistManager {
       countdown: playlistConfig ? playlistConfig.countdown : this.countdown,
       items: playlistData.items.map((item, index) => {
         const itemData = Utils.Object.copyDeep(item);
+        ['sources.dvr', 'sources.type'].forEach(omitKey => {
+          // use medias source data instead of playlist source data
+          Utils.Object.deletePropertyPath(itemData, omitKey);
+        });
         Utils.Object.mergeDeep(
           itemData.sources,
           playlistConfig && playlistConfig.items && playlistConfig.items[index] && playlistConfig.items[index].sources


### PR DESCRIPTION
### Description of the Changes

solves: https://kaltura.atlassian.net/browse/FEC-13241

UI uses incorrect preset for VOD media created from Live medias. Playlist multirequest contains outdated data about media type (Live instead of VOD), so "type" and "dvr" keys omitted (values uses from baseEntry multirequest)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
