### PR TITLE
fix(FEC-13209): [Audio Player] adjust full size player UI to entries of audio media type

### DIFF
--- a/src/kaltura-player.js
+++ b/src/kaltura-player.js
@@ -437,6 +437,10 @@ class KalturaPlayer extends FakeEventTarget {
     return hasImageSource(this.sources);
   }
 
+  isAudio(): boolean {
+    return this._localPlayer.isAudio();
+  }
+
   seekToLiveEdge(): void {
     this._localPlayer.seekToLiveEdge();
   }

--- a/types.d.ts
+++ b/types.d.ts
@@ -128,7 +128,7 @@ export interface SourcesMetadata {
   entryId?: string;
   name?: string;
   description?: string;
-  mediaType?: string,
+  mediaType?: string;
   metas?: Object;
   tags?: Object;
   epgId?: string;
@@ -140,15 +140,12 @@ export interface SourcesMetadata {
 export interface MediaSourceObject {
   mimetype: string;
   url: string;
-  id?: string,
+  id?: string;
   bandwidth?: number;
   width?: number;
   height?: number;
   drmData?: any[];
 }
-
-
-
 
 declare module PlaykitUI {
   export class EventManager {
@@ -189,24 +186,24 @@ declare module PlaykitUI {
   };
 
   export const ReservedPresetAreas: {
-    PlayerArea: 'PlayerArea',
-    PresetArea: 'PresetArea',
-    InteractiveArea: 'InteractiveArea',
-    VideoArea: 'VideoArea',
-    GuiArea: 'GuiArea',
-    TopBar: 'TopBar',
-    BottomBar: 'BottomBar',
-    PresetFloating: 'PresetFloating',
-    TopBarLeftControls: 'TopBarLeftControls',
-    TopBarRightControls: 'TopBarRightControls',
-    BottomBarLeftControls: 'BottomBarLeftControls',
-    BottomBarRightControls: 'BottomBarRightControls',
-    SidePanelTop: 'SidePanelTop',
-    SidePanelLeft: 'SidePanelLeft',
-    SidePanelRight: 'SidePanelRight',
-    SidePanelBottom: 'SidePanelBottom',
-    SeekBar: 'SeekBar',
-    LoadingSpinner: 'LoadingSpinner'
+    PlayerArea: 'PlayerArea';
+    PresetArea: 'PresetArea';
+    InteractiveArea: 'InteractiveArea';
+    VideoArea: 'VideoArea';
+    GuiArea: 'GuiArea';
+    TopBar: 'TopBar';
+    BottomBar: 'BottomBar';
+    PresetFloating: 'PresetFloating';
+    TopBarLeftControls: 'TopBarLeftControls';
+    TopBarRightControls: 'TopBarRightControls';
+    BottomBarLeftControls: 'BottomBarLeftControls';
+    BottomBarRightControls: 'BottomBarRightControls';
+    SidePanelTop: 'SidePanelTop';
+    SidePanelLeft: 'SidePanelLeft';
+    SidePanelRight: 'SidePanelRight';
+    SidePanelBottom: 'SidePanelBottom';
+    SeekBar: 'SeekBar';
+    LoadingSpinner: 'LoadingSpinner';
   };
 
   export const reducers: {
@@ -252,6 +249,13 @@ declare module PlaykitUI {
   };
 
   export const Components: {
+    ExpandableText: preactLib.ComponentClass<{
+      text: string;
+      lines: number;
+      forceShowMore?: boolean;
+      onClick?: () => void;
+      children: preactLib.ComponentChildren;
+    }>;
     Tooltip: preactLib.ComponentClass<{label: string}>;
     Icon: preactLib.ComponentClass<{
       id: string | number;


### PR DESCRIPTION
### Description of the Changes

Add ExpandableText type to types.d.ts

Related PRs:
https://github.com/kaltura/playkit-js-navigation/pull/334
https://github.com/kaltura/playkit-js-ui/pull/783

Resolves FEC-13209

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
