### PR TITLE
fix(FEC-13321): Captions default mode "Off" does not behave as expected

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ The configuration uses the following structure:
 > ##### Description: Defines the player dimensions configuration.
 
 ##
-  
+
 > ### config.abr
 >
 > ##### Type: [PKAbrConfigObject](https://github.com/kaltura/playkit-js/blob/master/docs/configuration.md#type-pkabrconfigobject)
@@ -151,7 +151,6 @@ The configuration uses the following structure:
 > ##### Type: [PKDrmConfigObject](https://github.com/kaltura/playkit-js/blob/master/docs/configuration.md#type-pkdrmconfigobject)
 >
 > ##### Description: Defines the drm system configuration.
-
 
 > ### config.playlist
 >
@@ -441,7 +440,7 @@ The configuration uses the following structure:
 
 > > If the autopause config is set to `autopause: true` the palyer will pause the playback when it gets out of view
 
-> > If floating player is configured, it will be used to float the player when it gets out of the view and it gets back to the place when you go into original viewport of player.  
+> > If floating player is configured, it will be used to float the player when it gets out of the view and it gets back to the place when you go into original viewport of player.
 
 > > ##### Properties
 > >
@@ -507,6 +506,7 @@ Default Player Configuration
 	textLanguage: '',
 	muted: false,
 	volume: 1,
+  captionsDisplay: false
 	autoplay: false
 }
 ```
@@ -519,6 +519,7 @@ Default Player Configuration
 	textLanguage: '',
 	muted: true,
 	volume: 0.7,
+  captionsDisplay: false,
 	autoplay: true
 }
 ```

--- a/docs/user-preferences.md
+++ b/docs/user-preferences.md
@@ -33,6 +33,7 @@ When a player instantiates, a partial configuration is created internally by the
 	volume: number,
 	audioLanguage: string,
 	textLanguage: string,
+	captionsDisplay: boolean,
 	textStyle: TextStyle
 }
 ```

--- a/src/common/storage/storage-manager.js
+++ b/src/common/storage/storage-manager.js
@@ -8,6 +8,7 @@ export default class StorageManager {
     VOLUME: 'volume',
     AUDIO_LANG: 'audioLanguage',
     TEXT_LANG: 'textLanguage',
+    CAPTIONS_DISPLAY: 'captionsDisplay',
     TEXT_STYLE: 'textStyle'
   };
 
@@ -61,13 +62,23 @@ export default class StorageManager {
 
     eventManager.listen(player, player.Event.UI.USER_SELECTED_CAPTION_TRACK, event => {
       const textTrack = event.payload.captionTrack;
-      StorageWrapper.setItem(StorageManager.StorageKeys.TEXT_LANG, textTrack.language);
+      if (textTrack.language !== 'off') {
+        StorageWrapper.setItem(StorageManager.StorageKeys.TEXT_LANG, textTrack.language);
+        StorageWrapper.setItem(StorageManager.StorageKeys.CAPTIONS_DISPLAY, true);
+      } else {
+        StorageWrapper.setItem(StorageManager.StorageKeys.CAPTIONS_DISPLAY, false);
+      }
     });
 
     const onToggleCaptions = () => {
       eventManager.listenOnce(player, player.Event.TEXT_TRACK_CHANGED, event => {
         const {selectedTextTrack} = event.payload;
-        StorageWrapper.setItem(StorageManager.StorageKeys.TEXT_LANG, selectedTextTrack.language);
+        if (selectedTextTrack.language !== 'off') {
+          StorageWrapper.setItem(StorageManager.StorageKeys.TEXT_LANG, selectedTextTrack.language);
+          StorageWrapper.setItem(StorageManager.StorageKeys.CAPTIONS_DISPLAY, true);
+        } else {
+          StorageWrapper.setItem(StorageManager.StorageKeys.CAPTIONS_DISPLAY, false);
+        }
       });
     };
 


### PR DESCRIPTION
### Description of the Changes

solves FEC-13321

**issue:** 'off' option kept at same field as the language (playback.textLanguage) 

**fix:** captions configuration and  state will be split into two, one state holds whether the captions are displayed or not, another state holds the captions language 

Consequently: the user preferences (cached in local storage) should be followed accordingly
that means that each of thotse state will be kept and consistent regardless of the other

configuration structure  change:
a new field is added: captionsDisplay

` {
     playback: {
	textLanguage: '',
        captionsDisplay: false,
       }
}`


related pr: https://github.com/kaltura/playkit-js/pull/722

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
