### PR TITLE
fix(FEC-13212): upgrade hls.js to 1.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@playkit-js/playkit-js-providers": "2.39.5",
     "@playkit-js/playkit-js-ui": "0.77.6",
     "@types/preact-i18n": "^2.3.1",
-    "hls.js": "1.3.5",
+    "hls.js": "1.4.11",
     "intersection-observer": "^0.12.0",
     "proxy-polyfill": "^0.3.0",
     "shaka-player": "4.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5430,10 +5430,10 @@ highlight.js@^10.7.2:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-hls.js@1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.3.5.tgz#0e8b0799ecf2feb7ba199f5e95f35ba9552e04f4"
-  integrity sha512-uybAvKS6uDe0MnWNEPnO0krWVr+8m2R0hJ/viql8H3MVK+itq8gGQuIYoFHL3rECkIpNH98Lw8YuuWMKZxp3Ew==
+hls.js@1.4.11:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.4.11.tgz#6ca2d7ab56f2725f27bb5f2e3c7982c6ec287118"
+  integrity sha512-rhPSUMACcIBbcUnwWnIcRgGXqJJt0xBRxvhzl99XpGHtnnLKjbczmmBmUuQueAQcbL3SdN7D5peAObR18VrhvQ==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Description of the Changes

Upgrade hls.js to 1.4.11

Related PR: https://github.com/kaltura/playkit-js-hls/pull/208

Resolves [FEC-13212](https://kaltura.atlassian.net/browse/FEC-13212)
Resolves [FEC-13322](https://kaltura.atlassian.net/browse/FEC-13322)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13212]: https://kaltura.atlassian.net/browse/FEC-13212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-13322]: https://kaltura.atlassian.net/browse/FEC-13322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ