### PR TITLE
fix(FEC-13347): wrong entry id reported by player when switching entries in playlist

### DIFF
--- a/src/common/playlist/playlist-manager.js
+++ b/src/common/playlist/playlist-manager.js
@@ -300,7 +300,7 @@ class PlaylistManager {
         new FakeEvent(PlaylistEventType.PLAYLIST_ITEM_CHANGED, {
           index,
           activeItem,
-          entryId: this._mediaInfoList[index]?.entryId || activeItem.sources.id
+          entryId: this._mediaInfoList[index]?.entryId || activeItem.sources?.id
         })
       );
       return Promise.resolve();

--- a/src/common/playlist/playlist-manager.js
+++ b/src/common/playlist/playlist-manager.js
@@ -296,7 +296,13 @@ class PlaylistManager {
       this._appPluginConfig = mergedPluginsConfigAndFromApp[1];
       const media = ({session: this._player.config.session, plugins: providerPlugins, sources: activeItem.sources}: any);
       this._player.setMedia(media);
-      this._player.dispatchEvent(new FakeEvent(PlaylistEventType.PLAYLIST_ITEM_CHANGED, {index, activeItem}));
+      this._player.dispatchEvent(
+        new FakeEvent(PlaylistEventType.PLAYLIST_ITEM_CHANGED, {
+          index,
+          activeItem,
+          entryId: this._mediaInfoList[index]?.entryId || activeItem.sources.id
+        })
+      );
       return Promise.resolve();
     } else {
       if (this._mediaInfoList[index]) {
@@ -306,7 +312,13 @@ class PlaylistManager {
         return this._player.loadMedia(this._mediaInfoList[index]).then(mediaConfig => {
           this._playlist.updateItemSources(index, mediaConfig.sources);
           this._playlist.updateItemPlugins(index, mediaConfig.plugins);
-          this._player.dispatchEvent(new FakeEvent(PlaylistEventType.PLAYLIST_ITEM_CHANGED, {index, activeItem}));
+          this._player.dispatchEvent(
+            new FakeEvent(PlaylistEventType.PLAYLIST_ITEM_CHANGED, {
+              index,
+              activeItem,
+              entryId: this._mediaInfoList[index].entryId
+            })
+          );
         });
       }
     }


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when listening to `PLAYLIST_ITEM_CHANGED` event for live entry (with VOD recording), the payload does not contain the live entry id, but the vod one. it is requested to know the live entry id as well.

**root cause:**
when switching entries in a playlist, in the 1st switching for each entry-
- `loadMedia` is being invoked
- which triggers `getMediaConfig`
- for live entry it returns its linked vod entry with its sources (as expected)
- then the sources of the playlistItem are being updated with what was returned from `getMediaConfig`

Hence, the live entry id is being overridden by the vod one.

**solution:**
when loading the playlist, we get the "original" list of entry ids of the playlist and we keep it in a private data structure called `mediaInfoList`; since we have access to that information when triggering `PLAYLIST_ITEM_CHANGED`, the solution is to pass another field named `entryId` on the payload of the event with the "original" entry id.

Solves FEC-13347

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
