### PR TITLE
fix: expose image type on Sources

### DIFF
--- a/ts-typed/player-config.d.ts
+++ b/ts-typed/player-config.d.ts
@@ -149,6 +149,7 @@ declare namespace KalturaPlayerTypes {
     hls?: Dash[];
     dash?: Dash[];
     progressive?: Progressive[];
+    image?: Dash[];
     id: string;
     duration?: number;
     type: EntryTypes;


### PR DESCRIPTION
### Description of the Changes

expose `image` object on Sources object in `player-config.d.ts` file.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
