### PR TITLE
fix(FEC-13426): Player v7| playlist| image entry cover the whole player and the user cannot navigate to another entry

### DIFF
--- a/src/common/playlist/playlist-manager.js
+++ b/src/common/playlist/playlist-manager.js
@@ -270,7 +270,7 @@ class PlaylistManager {
   }
 
   _onChangeSourceStarted(): void {
-    if (this._playlist.items[this._playlist._activeItemIndex].sources?.type === 'Image') {
+    if (this._player.isImage()) {
       this._player.configure({sources: {duration: this._options.imageDuration}});
     }
   }


### PR DESCRIPTION
### Description of the Changes

Image entries in playlist should always be timed images (with the source having duration) so that the ui shows prev and next buttons for them.
In playlist manager we check for the entry type to see if it's an image, and if so, we set the source duration to imageDuration (a field of the playlist).

At the point where we test this condition, playlistItem might have an empty type field, as its value set only after it's is copied from the source after setMedia. This would fail the condition and have duration stay not set.
The fix is to check the type of the source itself instead of checking the type of the playlistItem.

Resolves FEC-13426

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
