### PR TITLE
feat(FEC-13461): handle clip video query params

### DIFF
--- a/src/common/utils/setup-helpers.js
+++ b/src/common/utils/setup-helpers.js
@@ -23,6 +23,8 @@ const setupMessages: Array<Object> = [];
 const CONTAINER_CLASS_NAME: string = 'kaltura-player-container';
 const KALTURA_PLAYER_DEBUG_QS: string = 'debugKalturaPlayer';
 const KALTURA_PLAYER_START_TIME_QS: string = 'kalturaStartTime';
+const KALTURA_PLAYER_CLIP_START_TIME_QS: string = 'kalturaSeekFrom';
+const KALTURA_PLAYER_CLIP_END_TIME_QS: string = 'kalturaClipTo';
 const KAVA_DEFAULT_PARTNER = 2504201;
 const KAVA_DEFAULT_IMPRESSION = `https://analytics.kaltura.com/api_v3/index.php?service=analytics&action=trackEvent&apiVersion=3.3.0&format=1&eventType=1&partnerId=${KAVA_DEFAULT_PARTNER}&entryId=1_3bwzbc9o&&eventIndex=1&position=0`;
 
@@ -211,6 +213,23 @@ function maybeApplyStartTimeQueryParam(options: KPOptionsObject): void {
   let startTime = parseFloat(getUrlParameter(KALTURA_PLAYER_START_TIME_QS));
   if (!isNaN(startTime)) {
     Utils.Object.createPropertyPath(options, 'sources.startTime', startTime);
+  }
+}
+
+/**
+ * get the parameters for seekFrom and clipTo
+ * @private
+ * @param {KPOptionsObject} options - kaltura player options
+ * @returns {void}
+ */
+function maybeApplyClipQueryParams(options: KPOptionsObject): void {
+  let seekFrom = parseFloat(getUrlParameter(KALTURA_PLAYER_CLIP_START_TIME_QS));
+  if (!isNaN(seekFrom)) {
+    Utils.Object.createPropertyPath(options, 'sources.seekFrom', seekFrom);
+  }
+  let clipTo = parseFloat(getUrlParameter(KALTURA_PLAYER_CLIP_END_TIME_QS));
+  if (!isNaN(clipTo)) {
+    Utils.Object.createPropertyPath(options, 'sources.clipTo', clipTo);
   }
 }
 
@@ -759,6 +778,7 @@ export {
   validateProviderConfig,
   setLogOptions,
   maybeApplyStartTimeQueryParam,
+  maybeApplyClipQueryParams,
   createKalturaPlayerContainer,
   checkNativeHlsSupport,
   getDefaultOptions,

--- a/src/setup.js
+++ b/src/setup.js
@@ -7,6 +7,7 @@ import {
   attachToFirstClick,
   getDefaultOptions,
   maybeApplyStartTimeQueryParam,
+  maybeApplyClipQueryParams,
   printKalturaPlayerVersionToLog,
   printSetupMessages,
   setLogOptions,
@@ -31,6 +32,7 @@ function setup(options: PartialKPOptionsObject | LegacyPartialKPOptionsObject): 
   validateProviderConfig(defaultOptions);
   setLogOptions(defaultOptions);
   maybeApplyStartTimeQueryParam(defaultOptions);
+  maybeApplyClipQueryParams(defaultOptions);
   printSetupMessages();
   setStorageConfig(defaultOptions);
   const player = getPlayerProxy(defaultOptions);


### PR DESCRIPTION
### Description of the Changes

handles `seekFrom` and `clipTo` url query parameters, for clipping the video (changing the duration).

Solves FEC-13461

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
