### PR TITLE
fix(SUP-40695): [SmartTV][Cetin's bug] Player_SmartTV_Samsung - An in…

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -361,7 +361,7 @@ export class KalturaPlayer extends FakeEventTarget {
 
   public shouldAddKs(mediaConfig?: KPMediaConfig): boolean {
     return !!(
-      this.config.provider.loadThumbnailWithKs &&
+      this.config?.provider?.loadThumbnailWithKs &&
       (mediaConfig || this.config)?.session?.isAnonymous === false
     );
   }


### PR DESCRIPTION
issue:
on smart tv when switch between channels fast  "Cannot read properties of undefined" error occurred

solution:
add a check if the variable exist
