### PR TITLE
fix(FEC-13615): clip functionality is missing

### DIFF
--- a/src/common/thumbnail-manager.ts
+++ b/src/common/thumbnail-manager.ts
@@ -112,6 +112,25 @@ class ThumbnailManager {
     };
   };
 
+  private _maybeCutThumbnail = (baseUrl: string): string => {
+    const seekFromConfig = Utils.Object.getPropertyPath(
+      this._player.config.sources,
+      'seekFrom'
+    );
+    const clipToConfig = Utils.Object.getPropertyPath(
+      this._player.config.sources,
+      'clipTo'
+    );
+    let url = baseUrl;
+    if (seekFromConfig && typeof seekFromConfig === 'number') {
+      url += `/start_sec/${seekFromConfig}`;
+    }
+    if (clipToConfig && typeof clipToConfig === 'number') {
+      url += `/end_sec/${clipToConfig}`;
+    }
+    return url;
+  };
+
   private _getThumbSlicesUrl = (
     posterUrl: string | Poster[] | undefined,
     ks: string | undefined,
@@ -124,7 +143,8 @@ class ThumbnailManager {
             thumbnailUrl: posterUrl,
             ...thumbnailConfig
           };
-          const url = evaluate(THUMBNAIL_SERVICE_TEMPLATE, model);
+          const baseUrl = evaluate(THUMBNAIL_SERVICE_TEMPLATE, model);
+          const url = this._maybeCutThumbnail(baseUrl);
           return ks ? url + `/ks/${ks}` : url;
         } catch (e) {
           return '';

--- a/src/common/thumbnail-manager.ts
+++ b/src/common/thumbnail-manager.ts
@@ -122,10 +122,10 @@ class ThumbnailManager {
       'clipTo'
     );
     let url = baseUrl;
-    if (seekFromConfig && typeof seekFromConfig === 'number') {
+    if (typeof seekFromConfig === 'number') {
       url += `/start_sec/${seekFromConfig}`;
     }
-    if (clipToConfig && typeof clipToConfig === 'number') {
+    if (typeof clipToConfig === 'number') {
       url += `/end_sec/${clipToConfig}`;
     }
     return url;

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -17,6 +17,8 @@ const CLIENT_TAG = 'clientTag=html5:v';
 const UDRM_DOMAIN = 'kaltura.com';
 const CUSTOM_DATA = 'custom_data=';
 const SIGNATURE = 'signature=';
+const SEEK_FROM = 'seekFrom=';
+const CLIP_TO = 'clipTo=';
 
 /**
  * @param {Player} player - player
@@ -193,6 +195,31 @@ function addClientTag(url: string, productVersion?: string): string {
 }
 
 /**
+ * @param {string} url - url
+ * @param {PKSourcesConfigObject} sources - sources
+ * @return {string} - the url with the seekFrom and clipTo appended in the query params
+ * @private
+ */
+function addStartAndEndTime(
+  url: string,
+  sources: PKSourcesConfigObject
+): string {
+  const seekFrom = Utils.Object.getPropertyPath(sources, 'seekFrom');
+  const clipTo = Utils.Object.getPropertyPath(sources, 'clipTo');
+  if (
+    seekFrom &&
+    typeof seekFrom === 'number' &&
+    url.indexOf(SEEK_FROM) === -1
+  ) {
+    url += getQueryStringParamDelimiter(url) + SEEK_FROM + seekFrom * 1000;
+  }
+  if (clipTo && typeof clipTo === 'number' && url.indexOf(CLIP_TO) === -1) {
+    url += getQueryStringParamDelimiter(url) + CLIP_TO + clipTo * 1000;
+  }
+  return url;
+}
+
+/**
  * Adding Kaltura specific params to player config and player sources.
  * @param {Player} player - player
  * @param {PartialKPOptionsObject} playerConfig - player config
@@ -220,6 +247,7 @@ function addKalturaParams(
           source.url = updateSessionIdInUrl(source.url, sessionId);
           source.url = addReferrer(source.url);
           source.url = addClientTag(source.url, productVersion);
+          source.url = addStartAndEndTime(source.url, sources);
         }
         if (source['drmData'] && source['drmData'].length) {
           source['drmData'].forEach((drmData) => {

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -206,14 +206,10 @@ function addStartAndEndTime(
 ): string {
   const seekFrom = Utils.Object.getPropertyPath(sources, 'seekFrom');
   const clipTo = Utils.Object.getPropertyPath(sources, 'clipTo');
-  if (
-    seekFrom &&
-    typeof seekFrom === 'number' &&
-    url.indexOf(SEEK_FROM) === -1
-  ) {
+  if (typeof seekFrom === 'number' && url.indexOf(SEEK_FROM) === -1) {
     url += getQueryStringParamDelimiter(url) + SEEK_FROM + seekFrom * 1000;
   }
-  if (clipTo && typeof clipTo === 'number' && url.indexOf(CLIP_TO) === -1) {
+  if (typeof clipTo === 'number' && url.indexOf(CLIP_TO) === -1) {
     url += getQueryStringParamDelimiter(url) + CLIP_TO + clipTo * 1000;
   }
   return url;


### PR DESCRIPTION
### Description of the Changes

**Issue:**
a regression following migrating the repository to TS; the functionality of clipping video, using query params, was omitted.

**Fix:**
add back the code that is responsible of clipping the video according to [this PR](https://github.com/kaltura/kaltura-player-js/commit/e53698e786a8873cf25626e6960ef83c3ab19829).

#### Resolves FEC-13615
