### PR TITLE
feat(FEC-13540): allow passing entry id to start playing the playlist from

### DIFF
--- a/docs/playlist.md
+++ b/docs/playlist.md
@@ -86,6 +86,32 @@ For all playlist options, see [`KPPlaylistObject`](./api.md#kpplaylistobject).
 
 ## Configure the Playlist
 
+### StartAtEntryId
+
+By default, a playlist starts playing from the first entry.
+<br>To change this behavior, configure the [`options`](./api.md#kpplaylistoptions) under [`KPPlaylistConfigObject`](./api.md#kpplaylistconfigobject) using one of the following methods:
+<br>Via the API:
+
+```javascript
+kalturaPlayer.loadPlaylist({playlistId: '123456'}, {options: {startAtEntryId: '1_xxxxxx'}});
+```
+
+```javascript
+kalturaPlayer.loadPlaylistByEntryList({entries: [{entryId: '01234'}, {entryId: '56789'}]}, {options: {startAtEntryId: '1_xxxxxx'}});
+```
+
+By configuration:
+
+```javascript
+kalturaPlayer.configure({
+  playlist: {
+    options: {startAtEntryId: '1_xxxxxx'}
+  }
+});
+```
+
+For full playlist options see [`KPPlaylistOptions`](./api.md#kpplaylistoptions).
+
 ### Auto Continue
 
 By default, once the current item is ended, the playlist continues to the next item automatically.
@@ -230,4 +256,4 @@ kalturaPlayer.loadPlaylist({playlistId: '56789'}, {options: {autoContinue: true}
 
 ## Error Handling
 
-Error handling is based on player errors which may result from Kaltura api requests or media issues 
+Error handling is based on player errors which may result from Kaltura api requests or media issues

--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -67,7 +67,24 @@ class PlaylistManager {
         // @ts-ignore
         this._player.dispatchEvent(new FakeEvent(PlaylistEventType.PLAYLIST_LOADED, { playlist: this }));
         this._addBindings();
-        this.playNext();
+        const startPlaylistAtEntryId = config.options?.startAtEntryId;
+        let wasEntryIdSet = false;
+        if (
+          startPlaylistAtEntryId &&
+          typeof startPlaylistAtEntryId === 'string'
+        ) {
+          const entryToPlay: PlaylistItem | undefined =
+            this._playlist.items.find(
+              (item: PlaylistItem) => item.sources.id === startPlaylistAtEntryId
+            );
+          if (entryToPlay) {
+            wasEntryIdSet = true;
+            this.playItem(entryToPlay.index);
+          }
+        }
+        if (!wasEntryIdSet) {
+          this.playNext();
+        }
       }
     }
   }

--- a/src/types/playlist/playlist-options.ts
+++ b/src/types/playlist/playlist-options.ts
@@ -2,10 +2,12 @@
  * @typedef {Object} KPPlaylistOptions
  * @property {boolean} [autoContinue=true] - Determines whether to continue to the next item automatically.
  * @property {boolean} [loop=false] - Determines whether to play the playlist in a loop. When selected, the playlist will play automatically even if autoContinue is set to false.
+ * @property {string} [startAtEntryId] - Determines which entry id to start to the play the playlist from.
  */
 export interface PlaylistOptions {
   autoContinue: boolean;
   loop: boolean;
   imageDuration: number;
   documentDuration: number;
+  startAtEntryId?: string;
 }


### PR DESCRIPTION
### Description of the Changes

- **enhancement**

Add the ability to pass an entryId, to playlist API, which the playlist will start playing from.

#### Resolves [FEC-13540](https://kaltura.atlassian.net/browse/FEC-13540)


[FEC-13540]: https://kaltura.atlassian.net/browse/FEC-13540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ