### PR TITLE
fix(FEC-13685): Captions advanced settings text style is not saved

### DIFF
--- a/src/common/storage/base-storage-manager.ts
+++ b/src/common/storage/base-storage-manager.ts
@@ -152,7 +152,7 @@ export class BaseStorageManager {
     const obj = {};
     Object.keys(this.StorageKeys).forEach((key) => {
       const value = this.StorageKeys[key];
-      const item = this.getItem(value, this.getStorageObject());
+      const item = BaseStorageManager.getItem(value, this.getStorageObject());
       // dont change to !==, it effects the logic
       // eslint-disable-next-line
       if (item != null) {

--- a/src/common/storage/base-storage-manager.ts
+++ b/src/common/storage/base-storage-manager.ts
@@ -152,7 +152,7 @@ export class BaseStorageManager {
     const obj = {};
     Object.keys(this.StorageKeys).forEach((key) => {
       const value = this.StorageKeys[key];
-      const item = BaseStorageManager.getItem(value, this.getStorageObject());
+      const item = BaseStorageManager.getItem(value);
       // dont change to !==, it effects the logic
       // eslint-disable-next-line
       if (item != null) {

--- a/src/common/storage/base-storage-manager.ts
+++ b/src/common/storage/base-storage-manager.ts
@@ -152,7 +152,7 @@ export class BaseStorageManager {
     const obj = {};
     Object.keys(this.StorageKeys).forEach((key) => {
       const value = this.StorageKeys[key];
-      const item = BaseStorageManager.getItem(value);
+      const item = this.getItem(value);
       // dont change to !==, it effects the logic
       // eslint-disable-next-line
       if (item != null) {

--- a/src/common/storage/base-storage-manager.ts
+++ b/src/common/storage/base-storage-manager.ts
@@ -116,7 +116,7 @@ export class BaseStorageManager {
    * @returns {any} - The item value
    */
   public static getItem(key: string): any {
-    StorageWrapper.getItem(key, this.getStorageObject());
+    return StorageWrapper.getItem(key, this.getStorageObject());
   }
 
   /**
@@ -152,7 +152,7 @@ export class BaseStorageManager {
     const obj = {};
     Object.keys(this.StorageKeys).forEach((key) => {
       const value = this.StorageKeys[key];
-      const item = StorageWrapper.getItem(value, this.getStorageObject());
+      const item = this.getItem(value, this.getStorageObject());
       // dont change to !==, it effects the logic
       // eslint-disable-next-line
       if (item != null) {


### PR DESCRIPTION
### Description of the Changes

**Issue:**
Captions style is not saved
The bug only affected captions style because other uses of storage manager used StorageWrapper getItem directly

**Fix:**
Add return statement to BaseStorageManager.getItem and do not use StorageWrapper getItem directly outside of BaseStorageManager.getItem

Resolves FEC-13685
