### PR TITLE
feat(FEC-13652): add meaningful error message

### DIFF
--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -17,7 +17,7 @@ const conditionsToErrors: any[] = [
 ];
 
 function getErrorCategory(error: Error): number {
-  const [, errorCategory] = conditionsToErrors.find((errorCondition) => errorCondition[0](error) === true) || [];
+  const [, errorCategory] = conditionsToErrors.find((errorCondition) => errorCondition[0](error)) || [];
   return errorCategory || Error.Category.PLAYER;
 }
 

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -17,7 +17,8 @@ const conditionsToErrors = [
 ];
 
 function getErrorCategory(error: Error): number {
-  return conditionsToErrors.find((condition) => condition[0](error) === true) ? [1] : Error.Category.PLAYER;
+  const [, errorCategory] = conditionsToErrors.find((errorCondition) => errorCondition[0](error) === true) || [];
+  return errorCategory || Error.Category.PLAYER;
 }
 
 export default getErrorCategory;

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -10,7 +10,7 @@ const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);
 const isMediaNotReadyError = (error: Error): boolean => isBackEndError(error) && isMediaNotReady(error);
 
-const conditionsToErrors = [
+const conditionsToErrors: any[] = [
   [isSessionRestrictedError, Error.Category.MEDIA_UNAVAILABLE],
   [isGeolocationError, Error.Category.GEO_LOCATION],
   [isMediaNotReadyError, Error.Category.MEDIA_NOT_READY]

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -1,0 +1,23 @@
+import { Error } from '@playkit-js/playkit-js';
+
+const isBackEndError = (error: Error): boolean => error.category === 2;
+const isBlockAction = (error: Error): boolean => error.code === 2001;
+const isMediaNotReady = (error: Error): boolean => error.code === 2002;
+const isGeolocationRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'COUNTRY_RESTRICTED';
+const isSessionRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SESSION_RESTRICTED';
+
+const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSessionRestricted(error);
+const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);
+const isMediaNotReadyError = (error: Error): boolean => isBackEndError(error) && isMediaNotReady(error);
+
+const conditionsToErrors = [
+  [isSessionRestrictedError, Error.Category.MEDIA_UNAVAILABLE],
+  [isGeolocationError, Error.Category.GEO_LOCATION],
+  [isMediaNotReadyError, Error.Category.MEDIA_NOT_READY]
+];
+
+function getErrorCategory(error: Error): number {
+  return conditionsToErrors.find((condition) => condition[0](error) === true) ? [1] : Error.Category.PLAYER;
+}
+
+export default getErrorCategory;

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -76,6 +76,7 @@ import {
   HEVCConfigObject,
   MediaCapabilitiesObject
 } from './types';
+import getErrorCategory from './common/utils/error-helper';
 
 export class KalturaPlayer extends FakeEventTarget {
   private static _logger: any = getLogger('KalturaPlayer' + Utils.Generator.uniqueId(5));
@@ -170,32 +171,11 @@ export class KalturaPlayer extends FakeEventTarget {
       this.setMedia(mediaConfig);
       return mediaConfig;
     } catch (e) {
-      const category = this._getErrorCategory(e);
+      const category = getErrorCategory(e);
       const error = new Error(Error.Severity.CRITICAL, category, Error.Code.LOAD_FAILED, e);
       this._localPlayer.dispatchEvent(new FakeEvent(CoreEventType.ERROR, error));
       throw e;
     }
-  }
-
-  private _getErrorCategory(error: Error): number {
-    if (error.category === 2) {
-      // category is Service from provider - BE issue
-      if (error.code === 2001) {
-        // block action
-        const code = error.data?.messages ? error.data?.messages[0].code : '';
-        if (code === 'SESSION_RESTRICTED') {
-          return Error.Category.MEDIA_UNAVAILABLE;
-        }
-        if (code === 'COUNTRY_RESTRICTED') {
-          return Error.Category.GEO_LOCATION;
-        }
-      }
-      if (error.code === 2002) {
-        // media is not ready
-        return Error.Category.MEDIA_NOT_READY;
-      }
-    }
-    return Error.Category.PLAYER;
   }
 
   public setMedia(mediaConfig: KPMediaConfig): void {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -178,8 +178,10 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   private _getErrorCategory(error: Error): number {
-    if (error.category === 2) { // category is Service from provider - BE issue
-      if (error.code === 2001) { // block action
+    if (error.category === 2) {
+      // category is Service from provider - BE issue
+      if (error.code === 2001) {
+        // block action
         const code = error.data?.messages ? error.data?.messages[0].code : '';
         if (code === 'SESSION_RESTRICTED') {
           return Error.Category.MEDIA_UNAVAILABLE;
@@ -188,7 +190,8 @@ export class KalturaPlayer extends FakeEventTarget {
           return Error.Category.GEO_LOCATION;
         }
       }
-      if (error.code === 2002) { // media is not ready
+      if (error.code === 2002) {
+        // media is not ready
         return Error.Category.MEDIA_NOT_READY;
       }
     }


### PR DESCRIPTION
### Description of the Changes

inside catch block of `loadMedia`, we classify errors that might come from BE (through provider) as Player errors. However, we would like to recognize them and provide the `category` number that suits them.

**changes:**
- inside catch block of `loadMedia`, before firing the error as `Player` category, try to get the category according to the error payload.
- if category is `2`, it means it is `Service` category that came from `provider`
- code `2001` is block action error
- under `error.code = 2001` we need to distinguish between `SESSION_RESTRICTED` and `COUNTRY_RESTRICTED`
- code `2002` is media is not ready error
- fallback to `Player` category as default

#### Resolves FEC-13652
