### PR TITLE
feat(FEC-13871): set the entry name to navigator media metadata

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -169,6 +169,7 @@ export class KalturaPlayer extends FakeEventTarget {
       this._appPluginConfig = mergedPluginsConfigAndFromApp[1];
       this.configure(getDefaultRedirectOptions({ sources: this.sources }, mediaConfig));
       this.setMedia(mediaConfig);
+      this._configureMediaMetadata(mediaConfig);
       return mediaConfig;
     } catch (e) {
       const category = getErrorCategory(e);
@@ -821,6 +822,12 @@ export class KalturaPlayer extends FakeEventTarget {
 
   public get Error(): typeof Error {
     return this._localPlayer.Error;
+  }
+
+  private _configureMediaMetadata(mediaConfig: ProviderMediaConfigObject): void {
+    // here we can provide information about the media, to a device that is playing it
+    // set the media metadata title to the name of the entry
+    navigator.mediaSession.metadata = new MediaMetadata({title: mediaConfig.sources.metadata.name});
   }
 
   private _addBindings(): void {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -832,7 +832,7 @@ export class KalturaPlayer extends FakeEventTarget {
       if (typeof poster === 'string') {
         return poster;
       }
-      if (Array.isArray(poster) && poster.length >= 1) {
+      if (Array.isArray(poster) && poster.length > 0) {
         return poster[0];
       }
       return '';

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -828,7 +828,7 @@ export class KalturaPlayer extends FakeEventTarget {
     // here we can provide information about the media, to a device that is playing it
     // set the media metadata title to the name of the entry
     if (navigator.mediaSession) {
-      navigator.mediaSession.metadata = new MediaMetadata({ title: mediaConfig.sources.metadata.name });
+      navigator.mediaSession.metadata = new MediaMetadata({ title: mediaConfig.sources.metadata?.name });
     }
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -206,7 +206,7 @@ export class KalturaPlayer extends FakeEventTarget {
       playerConfig.playback = playback;
     }
     this.configure({ ...playerConfig, sources });
-    this._configureMediaMetadata(mediaConfig);
+    this._configureInformationForDevice(mediaConfig);
   }
 
   public async loadPlaylist(playlistInfo: ProviderPlaylistInfoObject, playlistConfig: PlaylistConfigObject): Promise<ProviderPlaylistObject> {
@@ -824,14 +824,26 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.Error;
   }
 
-  private _configureMediaMetadata(mediaConfig: KPMediaConfig): void {
+  private _configureInformationForDevice(mediaConfig: KPMediaConfig): void {
     // here we can provide information about the media, to a device that is playing it
     // set the media metadata title to the name of the entry, if exists
-    const mediaName = mediaConfig.sources.metadata?.name;
-    if (navigator.mediaSession && mediaName) {
-      navigator.mediaSession.metadata = new MediaMetadata({ title: mediaName });
-    } else if (navigator.mediaSession?.metadata) {
-      navigator.mediaSession.metadata = null;
+    // set the media thumbnail to appear as the background of a native device's player, if exists
+    const getMediaThumbnail = (poster: any): string => {
+      if (typeof poster === 'string') {
+        return poster;
+      }
+      if (Array.isArray(poster) && poster.length >= 1) {
+        return poster[0];
+      }
+      return '';
+    };
+
+    if (navigator.mediaSession) {
+      const mediaThumbnail = getMediaThumbnail(mediaConfig.sources.poster);
+      navigator.mediaSession.metadata = new MediaMetadata({
+        title: mediaConfig.sources.metadata?.name || '',
+        artwork: mediaThumbnail ? [{ src: mediaThumbnail }] : []
+      });
     }
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -826,9 +826,12 @@ export class KalturaPlayer extends FakeEventTarget {
 
   private _configureMediaMetadata(mediaConfig: KPMediaConfig): void {
     // here we can provide information about the media, to a device that is playing it
-    // set the media metadata title to the name of the entry
-    if (navigator.mediaSession) {
-      navigator.mediaSession.metadata = new MediaMetadata({ title: mediaConfig.sources.metadata?.name });
+    // set the media metadata title to the name of the entry, if exists
+    const mediaName = mediaConfig.sources.metadata?.name;
+    if (navigator.mediaSession && mediaName) {
+      navigator.mediaSession.metadata = new MediaMetadata({ title: mediaName });
+    } else if (navigator.mediaSession?.metadata) {
+      navigator.mediaSession.metadata = null;
     }
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -169,7 +169,6 @@ export class KalturaPlayer extends FakeEventTarget {
       this._appPluginConfig = mergedPluginsConfigAndFromApp[1];
       this.configure(getDefaultRedirectOptions({ sources: this.sources }, mediaConfig));
       this.setMedia(mediaConfig);
-      this._configureMediaMetadata(mediaConfig);
       return mediaConfig;
     } catch (e) {
       const category = getErrorCategory(e);
@@ -207,6 +206,7 @@ export class KalturaPlayer extends FakeEventTarget {
       playerConfig.playback = playback;
     }
     this.configure({ ...playerConfig, sources });
+    this._configureMediaMetadata(mediaConfig);
   }
 
   public async loadPlaylist(playlistInfo: ProviderPlaylistInfoObject, playlistConfig: PlaylistConfigObject): Promise<ProviderPlaylistObject> {
@@ -824,7 +824,7 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.Error;
   }
 
-  private _configureMediaMetadata(mediaConfig: ProviderMediaConfigObject): void {
+  private _configureMediaMetadata(mediaConfig: KPMediaConfig): void {
     // here we can provide information about the media, to a device that is playing it
     // set the media metadata title to the name of the entry
     if (navigator.mediaSession) {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -827,7 +827,7 @@ export class KalturaPlayer extends FakeEventTarget {
   private _configureMediaMetadata(mediaConfig: ProviderMediaConfigObject): void {
     // here we can provide information about the media, to a device that is playing it
     // set the media metadata title to the name of the entry
-    navigator.mediaSession.metadata = new MediaMetadata({title: mediaConfig.sources.metadata.name});
+    navigator.mediaSession.metadata = new MediaMetadata({ title: mediaConfig.sources.metadata.name });
   }
 
   private _addBindings(): void {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -827,7 +827,9 @@ export class KalturaPlayer extends FakeEventTarget {
   private _configureMediaMetadata(mediaConfig: ProviderMediaConfigObject): void {
     // here we can provide information about the media, to a device that is playing it
     // set the media metadata title to the name of the entry
-    navigator.mediaSession.metadata = new MediaMetadata({ title: mediaConfig.sources.metadata.name });
+    if (navigator.mediaSession) {
+      navigator.mediaSession.metadata = new MediaMetadata({ title: mediaConfig.sources.metadata.name });
+    }
   }
 
   private _addBindings(): void {


### PR DESCRIPTION
### Description of the Changes

when playing a media on a mobile device and exiting the browser- the request is for the mobile device to show the entry name of the media that is played and the thumbnail as the background, in the native device player.

- using `MediaMetadata` object to pass to the `navigator.mediaSession`
- configuring the navigator `mediaSession` in `setMedia` to cover playlist and setMedia use-cases
- in case there is not entry name or poster, resetting to empty string so it will not show the previews information 

#### Resolves FEC-13871
