### PR TITLE
fix(FEC-13931): Audio player| canary audio player version failed to load

### DIFF
--- a/demo/player-ovp.html
+++ b/demo/player-ovp.html
@@ -18,16 +18,16 @@
         },
         targetId: 'player-placeholder',
         provider: {
-          partnerId: 242,
+          partnerId: 1091,
           env: {
-            serviceUrl: 'https://api.nvq2.ovp.kaltura.com/api_v3',
-            cdnUrl: 'https://api.nvq2.ovp.kaltura.com'
+            cdnUrl: 'https://qa-apache-php7.dev.kaltura.com/',
+            serviceUrl: 'https://qa-apache-php7.dev.kaltura.com/api_v3'
           }
         }
       };
 
       const player = KalturaPlayer.setup(config);
-      player.loadMedia({ entryId: '0_vry5u8hk' });
+      player.loadMedia({ entryId: '0_wifqaipd' });
     </script>
   </body>
 </html>

--- a/src/common/ui-wrapper.ts
+++ b/src/common/ui-wrapper.ts
@@ -26,8 +26,8 @@ class UIWrapper {
       }
     } else {
       this._uiManager = new UIManager(player, config);
-      if (config.customPreset || window.kaltruCcustomPreset) {
-        this._uiManager.buildCustomUI(config.customPreset || window.kaltruCcustomPreset);
+      if (config.customPreset || window.kalturaCustomPreset) {
+        this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPreset);
       } else {
         this._uiManager.buildDefaultUI();
       }

--- a/src/common/ui-wrapper.ts
+++ b/src/common/ui-wrapper.ts
@@ -26,8 +26,8 @@ class UIWrapper {
       }
     } else {
       this._uiManager = new UIManager(player, config);
-      if (config.customPreset) {
-        this._uiManager.buildCustomUI(config.customPreset);
+      if (config.customPreset || window.kaltruCcustomPreset) {
+        this._uiManager.buildCustomUI(config.customPreset || window.kaltruCcustomPreset);
       } else {
         this._uiManager.buildDefaultUI();
       }

--- a/src/types/global/globals.d.ts
+++ b/src/types/global/globals.d.ts
@@ -1,5 +1,6 @@
 // globals.d.ts
 declare var __kalturaplayerdata: any;
+declare var kalturaCustomPreset: any;
 declare var DEBUG_KALTURA_PLAYER: boolean;
 declare var __NAME__: string;
 declare var __VERSION__: string;


### PR DESCRIPTION
### Description of the Changes

**Issue:** the gloabal back-end var window.__kalturaplayerdata is declared after the player and plugins code in bundle file

**Fix:** set a dedicated var for custom preset

#### Resolves FEC-13931

#### Related PR
https://github.com/kaltura/playkit-js-audio-player/pull/20

