### PR TITLE
fix(FEC-13878): copy the hls.worker.js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "source-map-loader": "^4.0.1",
     "standard-version": "^9.5.0",
     "style-loader": "3.3.3",
-    "terser-webpack-plugin": "^5.3.9",
+    "terser-webpack-plugin": "^5.3.10",
     "typescript": "^5.2.2",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const packageData = require('./package.json');
 const chalk = require('chalk');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = (env, { mode }) => {
   const { playerType } = env;
@@ -26,6 +27,10 @@ module.exports = (env, { mode }) => {
     target: 'web',
     entry: './src/index.ts',
     devtool: 'source-map',
+    optimization: {
+      minimize: true,
+      minimizer: [new TerserPlugin({terserOptions: {mangle: {reserved: ['module']}}})],
+    },
     module: {
       rules: [
         {
@@ -104,10 +109,6 @@ module.exports = (env, { mode }) => {
             transform: function (content) {
               return JSON.stringify(JSON.parse(content));
             }
-          },
-          {
-            from: 'node_modules/hls.js/dist/hls.worker.js',
-            to: 'hls.worker.js'
           }
         ]
       })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,6 @@ module.exports = (env, { mode }) => {
     entry: './src/index.ts',
     devtool: 'source-map',
     optimization: {
-      minimize: true,
       minimizer: [new TerserPlugin({terserOptions: {mangle: {reserved: ['module']}}})],
     },
     module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,6 +104,10 @@ module.exports = (env, { mode }) => {
             transform: function (content) {
               return JSON.stringify(JSON.parse(content));
             }
+          },
+          {
+            from: 'node_modules/hls.js/dist/hls.worker.js',
+            to: 'hls.worker.js'
           }
         ]
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5559,7 +5559,7 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-terser-webpack-plugin@^5.3.7, terser-webpack-plugin@^5.3.9:
+terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.7:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==


### PR DESCRIPTION
### Description of the Changes

**the issue:**
for source only entries which we don't know where are the keyframes (i.e. zoom integration), the playback get stuck after making seek several times to different positions in the playback.

**solution:**
after investigating the issue, seems to only be an hlsjs issue, where hls is reducing the max buffer length to a value that is lower than the fragment duration.
when setting hls `enableWorker` configuration to `true`, the issue cannot be reproduced anymore.
at some point we disabled the worker since it stopped working and generated an error to the console (see relevant PR [here](https://github.com/kaltura/playkit-js-hls/pull/212/files)); in the current solution we make the worker work again by resolving the original issue of hls worker & webpak.

**related PR:** https://github.com/kaltura/playkit-js-hls/pull/218

#### Resolves FEC-13878
