### PR TITLE
fix(SUP-42321):V7 Player Not Working With Latest iOS Version

### DIFF
--- a/src/common/cuepoint/cuepoint-manager.ts
+++ b/src/common/cuepoint/cuepoint-manager.ts
@@ -67,16 +67,16 @@ export class CuePointManager {
 
   private _removeTextTrackCue(cue: TextTrackCue): void {
     const metadataTracks = this._getMetadataTracks();
-    for (const track in metadataTracks) {
+    metadataTracks.some((track) => {
       try {
         if (track.cues!.getCueById(cue.id)) {
           track.removeCue(cue);
-          return;
+          return true;
         }
       } catch {
         // do nothing
       }
-    }
+    });
   }
 
   public addCuePoints(data: CuePoint[]): void {

--- a/src/common/cuepoint/cuepoint-manager.ts
+++ b/src/common/cuepoint/cuepoint-manager.ts
@@ -67,13 +67,16 @@ export class CuePointManager {
 
   private _removeTextTrackCue(cue: TextTrackCue): void {
     const metadataTracks = this._getMetadataTracks();
-    metadataTracks.forEach((track) => {
+    for (const track in metadataTracks) {
       try {
-        track.removeCue(cue);
+        if (track.cues!.getCueById(cue.id)) {
+          track.removeCue(cue);
+          return;
+        }
       } catch {
         // do nothing
       }
-    });
+    }
   }
 
   public addCuePoints(data: CuePoint[]): void {


### PR DESCRIPTION
issue:
when play live with slides on ios version 17.4.1 and above page got refreshed and collapsed

fix:
when remove cuepoint from track:
* after cuepoint was removed there is no need to continue checking metadataTracks
* check if cuepoint exist for this specific track and only then remove it

solved [SUP-42321](https://kaltura.atlassian.net/browse/SUP-42321)



[SUP-42321]: https://kaltura.atlassian.net/browse/SUP-42321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ