### PR TITLE
feat(FEC-13946): Player core - Use shaka preload mechanism during playlist playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@playkit-js/playkit-js-providers": "2.40.5",
     "@playkit-js/playkit-js-ui": "0.79.1-canary.0-24968c4",
     "hls.js": "^1.5.8",
-    "shaka-player": "4.7.0"
+    "shaka-player": "4.8.11"
   },
   "devDependencies": {
     "@babel/core": "^7.22.20",

--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -389,7 +389,7 @@ class PlaylistManager {
 
           let sessionId = this._player.sessionIdCache?.get(mediaConfig.sources.id);
           if (!sessionId) {
-            sessionId = SessionIdGenerator.get();
+            sessionId = SessionIdGenerator.next();
             this._player.sessionIdCache?.set(mediaConfig.sources.id, sessionId);
           }
 
@@ -435,7 +435,7 @@ class PlaylistManager {
 
       let sessionId = this._player.sessionIdCache?.get(mediaConfig.sources.id);
       if (!sessionId) {
-        sessionId = SessionIdGenerator.get();
+        sessionId = SessionIdGenerator.next();
         this._player.sessionIdCache?.set(mediaConfig.sources.id, sessionId);
       }
 

--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -11,6 +11,8 @@ import { Playlist } from './playlist';
 import { PlaylistItem } from './playlist-item';
 import { mergeProviderPluginsConfig } from '../utils/setup-helpers';
 import { PlaylistOptions, PlaylistCountdownOptions, KalturaPlayerConfig, PluginsConfig, KPPlaylistObject, PlaylistConfigObject } from '../../types';
+import { addClientTag, addReferrer, addStartAndEndTime, updateSessionIdInUrl } from '../utils/kaltura-params';
+import { SessionIdGenerator } from '../utils/session-id-generator';
 
 /**
  * @class PlaylistManager
@@ -332,6 +334,25 @@ class PlaylistManager {
     }
     this._player.configure({ playback });
     this._playlist.activeItemIndex = index;
+
+    const promises: Promise<any>[] = [];
+
+    if (this._playlist.items[index - 1]) {
+      promises.push(this.prepareEntry(index - 1));
+    }
+    if (this._playlist.items[index + 1]) {
+      promises.push(this.prepareEntry(index + 1));
+    }
+
+    Promise.all(promises).then((mediaConfigs) => {
+      let cachedUrls = [];
+      for (const mediaConfig of mediaConfigs) {
+        cachedUrls = cachedUrls.concat(mediaConfig.sources.dash.map((dashSource) => dashSource.url));
+      }
+
+      this._player.setCachedUrls(cachedUrls);
+    });
+
     if (activeItem.isPlayable()) {
       this._resetProviderPluginsConfig();
       const mergedPluginsConfigAndFromApp = mergeProviderPluginsConfig(activeItem.plugins, this._player.config.plugins);
@@ -365,6 +386,21 @@ class PlaylistManager {
         return this._player.loadMedia(this._mediaInfoList[index]).then((mediaConfig) => {
           this._playlist.updateItemSources(index, mediaConfig.sources);
           this._playlist.updateItemPlugins(index, mediaConfig.plugins);
+
+          let sessionId = this._player.sessionIdCache?.get(mediaConfig.sources.id);
+          if (!sessionId) {
+            sessionId = SessionIdGenerator.get();
+            this._player.sessionIdCache?.set(mediaConfig.sources.id, sessionId);
+          }
+
+          mediaConfig.sources.dash = mediaConfig.sources.dash.map((source) => {
+            source.url = updateSessionIdInUrl(this._player, source.url, sessionId);
+            source.url = addReferrer(source.url);
+            source.url = addClientTag(source.url, mediaConfig.productVersion);
+            source.url = addStartAndEndTime(source.url, mediaConfig.sources);
+            return source;
+          });
+
           // eslint-disable-next-line  @typescript-eslint/ban-ts-comment
           // @ts-ignore
           this._player.dispatchEvent(
@@ -387,6 +423,32 @@ class PlaylistManager {
 
   public destroy(): void {
     this._eventManager.destroy();
+  }
+
+  private prepareEntry(index: number): Promise<any> {
+    if (this._playlist.items[index].isPlayable()) return Promise.resolve({ sources: this._playlist.items[index].sources });
+
+    return this._player.provider.getMediaConfig(this._mediaInfoList[index]).then((providerMediaConfig) => {
+      const mediaConfig = Utils.Object.copyDeep(providerMediaConfig);
+      this._playlist.updateItemSources(index, mediaConfig.sources);
+      this._playlist.updateItemPlugins(index, mediaConfig.plugins);
+
+      let sessionId = this._player.sessionIdCache?.get(mediaConfig.sources.id);
+      if (!sessionId) {
+        sessionId = SessionIdGenerator.get();
+        this._player.sessionIdCache?.set(mediaConfig.sources.id, sessionId);
+      }
+
+      mediaConfig.sources.dash = mediaConfig.sources.dash.map((source) => {
+        source.url = updateSessionIdInUrl(this._player, source.url, sessionId);
+        source.url = addReferrer(source.url);
+        source.url = addClientTag(source.url, mediaConfig.productVersion);
+        source.url = addStartAndEndTime(source.url, mediaConfig.sources);
+        return source;
+      });
+
+      return Promise.resolve(mediaConfig);
+    });
   }
 }
 

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -3,7 +3,6 @@ import { getServerUIConf } from './setup-helpers';
 import { KalturaPlayer } from '../../kaltura-player';
 import { PartialKPOptionsObject } from '../../types';
 import { SessionIdGenerator } from './session-id-generator';
-import { SessionIdCache } from './session-id-cache';
 
 const PLAY_MANIFEST = 'playmanifest/';
 const PLAY_SESSION_ID = 'playSessionId=';

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -54,14 +54,16 @@ function addSessionId(playerConfig: PartialKPOptionsObject): void {
 function updateSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsObject): void {
   const entryId = playerConfig.sources?.id;
 
-  if (!player?.playlist?.items?.length || !entryId) {
+  if (!player?.playlist?.items?.length) {
     setSessionId(playerConfig, SessionIdGenerator.get());
-  } else if (player.sessionIdCache?.get(entryId)) {
-    setSessionId(playerConfig, player.sessionIdCache?.get(entryId));
-  } else {
-    const sessionId = SessionIdGenerator.get();
-    player.sessionIdCache?.set(entryId, sessionId);
-    setSessionId(playerConfig, sessionId);
+  } else if (entryId) {
+    if (player.sessionIdCache?.get(entryId)) {
+      setSessionId(playerConfig, player.sessionIdCache?.get(entryId));
+    } else {
+      const sessionId = SessionIdGenerator.get();
+      player.sessionIdCache?.set(entryId, sessionId);
+      setSessionId(playerConfig, sessionId);
+    }
   }
 }
 

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -29,8 +29,8 @@ function handleSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsOb
   } else {
     // on first playback
     addSessionId(playerConfig);
-    if (player?.playlist?.items?.length) {
-      player.sessionIdCache?.set(playerConfig.sources.id, playerConfig.session!.id);
+    if (player?.playlist?.items?.length && playerConfig.sources?.id) {
+      player.sessionIdCache?.set(playerConfig.sources.id, playerConfig.session!.id as string);
     }
   }
 }

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -2,6 +2,8 @@ import { PKSourcesConfigObject, PlayerStreamTypes, StreamType, Utils } from '@pl
 import { getServerUIConf } from './setup-helpers';
 import { KalturaPlayer } from '../../kaltura-player';
 import { PartialKPOptionsObject } from '../../types';
+import { SessionIdGenerator } from './session-id-generator';
+import { SessionIdCache } from './session-id-cache';
 
 const PLAY_MANIFEST = 'playmanifest/';
 const PLAY_SESSION_ID = 'playSessionId=';
@@ -28,6 +30,9 @@ function handleSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsOb
   } else {
     // on first playback
     addSessionId(playerConfig);
+    if (player?.playlist?.items?.length) {
+      player.sessionIdCache?.set(playerConfig.sources.id, playerConfig.session.id);
+    }
   }
 }
 
@@ -37,9 +42,7 @@ function handleSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsOb
  * @private
  */
 function addSessionId(playerConfig: PartialKPOptionsObject): void {
-  const primaryGUID = Utils.Generator.guid();
-  const secondGUID = Utils.Generator.guid();
-  setSessionId(playerConfig, primaryGUID + ':' + secondGUID);
+  setSessionId(playerConfig, SessionIdGenerator.get());
 }
 
 /**
@@ -49,19 +52,16 @@ function addSessionId(playerConfig: PartialKPOptionsObject): void {
  * @private
  */
 function updateSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsObject): void {
-  const secondGuidInSessionIdRegex = /:((?:[a-z0-9]|-)*)/i;
-  const secondGuidInSessionId = secondGuidInSessionIdRegex.exec(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    player.config.session.id
-  );
-  if (secondGuidInSessionId && secondGuidInSessionId[1]) {
-    setSessionId(
-      playerConfig,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      player.config.session.id.replace(secondGuidInSessionId[1], Utils.Generator.guid())
-    );
+  const entryId = playerConfig.sources?.id;
+
+  if (!player?.playlist?.items?.length || !entryId) {
+    setSessionId(playerConfig, SessionIdGenerator.get());
+  } else if (player.sessionIdCache?.get(entryId)) {
+    setSessionId(playerConfig, player.sessionIdCache?.get(entryId));
+  } else {
+    const sessionId = SessionIdGenerator.get();
+    player.sessionIdCache?.set(entryId, sessionId);
+    setSessionId(playerConfig, sessionId);
   }
 }
 
@@ -83,13 +83,16 @@ function setSessionId(playerConfig: PartialKPOptionsObject, sessionId: string): 
  * @return {string} - the url with the new sessionId
  * @private
  */
-function updateSessionIdInUrl(url: string, sessionId?: string, paramName: string = PLAY_SESSION_ID): string {
+function updateSessionIdInUrl(player: KalturaPlayer | null, url: string, sessionId?: string, paramName: string = PLAY_SESSION_ID): string {
   if (sessionId) {
     const sessionIdInUrlRegex = new RegExp(paramName + '((?:[a-z0-9]|-)*:(?:[a-z0-9]|-)*)', 'i');
     const sessionIdInUrl = sessionIdInUrlRegex.exec(url);
+    // this url has session id (has already been played)
     if (sessionIdInUrl && sessionIdInUrl[1]) {
-      // this url has session id (has already been played)
-      url = url.replace(sessionIdInUrl[1], sessionId);
+      // session id should be the same for the same entry
+      if (!player?.playlist?.items?.length) {
+        url = url.replace(sessionIdInUrl[1], sessionId);
+      }
     } else {
       url += getQueryStringParamDelimiter(url) + paramName + sessionId;
     }
@@ -201,7 +204,7 @@ function addKalturaParams(player: KalturaPlayer, playerConfig: PartialKPOptionsO
           // @ts-ignore
           !source.localSource
         ) {
-          source.url = updateSessionIdInUrl(source.url, sessionId);
+          source.url = updateSessionIdInUrl(player, source.url, sessionId);
           source.url = addReferrer(source.url);
           source.url = addClientTag(source.url, productVersion);
           source.url = addStartAndEndTime(source.url, sources);
@@ -209,7 +212,7 @@ function addKalturaParams(player: KalturaPlayer, playerConfig: PartialKPOptionsO
         if (source['drmData'] && source['drmData'].length) {
           source['drmData'].forEach((drmData) => {
             if (typeof drmData.licenseUrl === 'string' && [UDRM_DOMAIN, CUSTOM_DATA, SIGNATURE].every((t) => drmData.licenseUrl.includes(t))) {
-              drmData.licenseUrl = updateSessionIdInUrl(drmData.licenseUrl, sessionId, DRM_SESSION_ID);
+              drmData.licenseUrl = updateSessionIdInUrl(player, drmData.licenseUrl, sessionId, DRM_SESSION_ID);
               drmData.licenseUrl = addClientTag(drmData.licenseUrl, productVersion);
               drmData.licenseUrl = addReferrer(drmData.licenseUrl);
               drmData.licenseUrl = addUIConfId(drmData.licenseUrl, playerConfig);
@@ -221,4 +224,4 @@ function addKalturaParams(player: KalturaPlayer, playerConfig: PartialKPOptionsO
   });
 }
 
-export { addKalturaParams, handleSessionId, updateSessionIdInUrl, getReferrer, addReferrer, addClientTag, addUIConfId };
+export { addKalturaParams, handleSessionId, updateSessionIdInUrl, getReferrer, addReferrer, addClientTag, addUIConfId, addStartAndEndTime };

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -30,7 +30,7 @@ function handleSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsOb
     // on first playback
     addSessionId(playerConfig);
     if (player?.playlist?.items?.length) {
-      player.sessionIdCache?.set(playerConfig.sources.id, playerConfig.session.id);
+      player.sessionIdCache?.set(playerConfig.sources.id, playerConfig.session!.id);
     }
   }
 }

--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -41,7 +41,7 @@ function handleSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsOb
  * @private
  */
 function addSessionId(playerConfig: PartialKPOptionsObject): void {
-  setSessionId(playerConfig, SessionIdGenerator.get());
+  setSessionId(playerConfig, SessionIdGenerator.next());
 }
 
 /**
@@ -54,12 +54,12 @@ function updateSessionId(player: KalturaPlayer, playerConfig: PartialKPOptionsOb
   const entryId = playerConfig.sources?.id;
 
   if (!player?.playlist?.items?.length) {
-    setSessionId(playerConfig, SessionIdGenerator.get());
+    setSessionId(playerConfig, SessionIdGenerator.next());
   } else if (entryId) {
     if (player.sessionIdCache?.get(entryId)) {
       setSessionId(playerConfig, player.sessionIdCache?.get(entryId));
     } else {
-      const sessionId = SessionIdGenerator.get();
+      const sessionId = SessionIdGenerator.next();
       player.sessionIdCache?.set(entryId, sessionId);
       setSessionId(playerConfig, sessionId);
     }

--- a/src/common/utils/session-id-cache.ts
+++ b/src/common/utils/session-id-cache.ts
@@ -2,16 +2,10 @@ class SessionIdCache {
   private cache = new Map();
 
   public set(key: string, value: string) {
-    // debugger;
-
-    console.log('>>> SessionIdCache.set', key, value);
-
     this.cache.set(key, value);
   }
 
-  public get(key: string) {
-    console.log('>>> SessionIdCache.get', key, this.cache.get(key));
-
+  public get(key: string): string {
     return this.cache.get(key);
   }
 

--- a/src/common/utils/session-id-cache.ts
+++ b/src/common/utils/session-id-cache.ts
@@ -1,7 +1,7 @@
 class SessionIdCache {
   private cache = new Map();
 
-  public set(key: string, value: string) {
+  public set(key: string, value: string): void {
     this.cache.set(key, value);
   }
 
@@ -9,7 +9,7 @@ class SessionIdCache {
     return this.cache.get(key);
   }
 
-  public clear() {
+  public clear(): void {
     this.cache.clear();
   }
 }

--- a/src/common/utils/session-id-cache.ts
+++ b/src/common/utils/session-id-cache.ts
@@ -1,0 +1,23 @@
+class SessionIdCache {
+  private cache = new Map();
+
+  public set(key: string, value: string) {
+    // debugger;
+
+    console.log('>>> SessionIdCache.set', key, value);
+
+    this.cache.set(key, value);
+  }
+
+  public get(key: string) {
+    console.log('>>> SessionIdCache.get', key, this.cache.get(key));
+
+    return this.cache.get(key);
+  }
+
+  public clear() {
+    this.cache.clear();
+  }
+}
+
+export { SessionIdCache };

--- a/src/common/utils/session-id-generator.ts
+++ b/src/common/utils/session-id-generator.ts
@@ -1,24 +1,24 @@
 import { Utils } from '@playkit-js/playkit-js';
 
 class SessionIdGenerator {
-  private static next: string = '';
+  private static _value: string = '';
 
-  private static init() {
-    SessionIdGenerator.next = `${Utils.Generator.guid()}:${Utils.Generator.guid()}`;
+  private static init(): void {
+    SessionIdGenerator._value = `${Utils.Generator.guid()}:${Utils.Generator.guid()}`;
   }
 
-  public static get() {
+  public static next(): string {
     if (!SessionIdGenerator.next) {
       this.init();
-      return SessionIdGenerator.next;
+      return SessionIdGenerator._value;
     }
 
-    const next = SessionIdGenerator.next;
+    const next = SessionIdGenerator._value;
 
     const secondGuidInSessionIdRegex = /:((?:[a-z0-9]|-)*)/i;
     const secondGuidInSessionId = secondGuidInSessionIdRegex.exec(next);
     if (secondGuidInSessionId && secondGuidInSessionId[1]) {
-      SessionIdGenerator.next = next.replace(secondGuidInSessionId[1], Utils.Generator.guid());
+      SessionIdGenerator._value = next.replace(secondGuidInSessionId[1], Utils.Generator.guid());
     }
 
     return next;

--- a/src/common/utils/session-id-generator.ts
+++ b/src/common/utils/session-id-generator.ts
@@ -1,0 +1,28 @@
+import { Utils } from '@playkit-js/playkit-js';
+
+class SessionIdGenerator {
+  private static next: string = '';
+
+  private static init() {
+    SessionIdGenerator.next = `${Utils.Generator.guid()}:${Utils.Generator.guid()}`;
+  }
+
+  public static get() {
+    if (!SessionIdGenerator.next) {
+      this.init();
+      return SessionIdGenerator.next;
+    }
+
+    const next = SessionIdGenerator.next;
+
+    const secondGuidInSessionIdRegex = /:((?:[a-z0-9]|-)*)/i;
+    const secondGuidInSessionId = secondGuidInSessionIdRegex.exec(next);
+    if (secondGuidInSessionId && secondGuidInSessionId[1]) {
+      SessionIdGenerator.next = next.replace(secondGuidInSessionId[1], Utils.Generator.guid());
+    }
+
+    return next;
+  }
+}
+
+export { SessionIdGenerator };

--- a/src/common/utils/session-id-generator.ts
+++ b/src/common/utils/session-id-generator.ts
@@ -8,7 +8,7 @@ class SessionIdGenerator {
   }
 
   public static next(): string {
-    if (!SessionIdGenerator.next) {
+    if (!SessionIdGenerator._value) {
       this.init();
       return SessionIdGenerator._value;
     }

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -100,7 +100,7 @@ function validateProviderConfig(options: KalturaPlayerConfig): void {
     source.url = addProductVersion(source.url, productVersion);
     source.url = addReferrer(source.url);
     source.url = addClientTag(source.url, productVersion);
-    source.url = updateSessionIdInUrl(null, source.url, SessionIdGenerator.get());
+    source.url = updateSessionIdInUrl(null, source.url, SessionIdGenerator.next());
     navigator.sendBeacon && navigator.sendBeacon(source.url);
   }
 }

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -23,6 +23,7 @@ import SessionStorageManager from '../storage/session-storage-manager';
 import { BaseStorageManager } from '../storage/base-storage-manager';
 import { BasePlugin } from '../plugins';
 import { KalturaPlayerConfig, LegacyPartialKPOptionsObject, PartialKPOptionsObject, PluginsConfig, PlaybackConfig } from '../../types';
+import { SessionIdGenerator } from './session-id-generator';
 
 const setupMessages: Array<any> = [];
 const CONTAINER_CLASS_NAME: string = 'kaltura-player-container';
@@ -99,7 +100,7 @@ function validateProviderConfig(options: KalturaPlayerConfig): void {
     source.url = addProductVersion(source.url, productVersion);
     source.url = addReferrer(source.url);
     source.url = addClientTag(source.url, productVersion);
-    source.url = updateSessionIdInUrl(source.url, Utils.Generator.guid() + ':' + Utils.Generator.guid());
+    source.url = updateSessionIdInUrl(null, source.url, SessionIdGenerator.get());
     navigator.sendBeacon && navigator.sendBeacon(source.url);
   }
 }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -77,6 +77,7 @@ import {
   MediaCapabilitiesObject
 } from './types';
 import getErrorCategory from './common/utils/error-helper';
+import { SessionIdCache } from './common/utils/session-id-cache';
 
 export class KalturaPlayer extends FakeEventTarget {
   private static _logger: any = getLogger('KalturaPlayer' + Utils.Generator.uniqueId(5));
@@ -106,10 +107,12 @@ export class KalturaPlayer extends FakeEventTarget {
   private _serviceProvider: ServiceProvider;
   private _isVisible: boolean = false;
   private _autoPaused: boolean = false;
+  private _sessionIdCache: SessionIdCache | null = null;
 
   constructor(options: KalturaPlayerConfig) {
     super();
     const { sources, plugins } = options;
+    this._sessionIdCache = new SessionIdCache();
     this._configEvaluator = new ConfigEvaluator();
     this._configEvaluator.evaluatePluginsConfig(plugins, options);
     this._playbackStart = false;
@@ -369,6 +372,7 @@ export class KalturaPlayer extends FakeEventTarget {
     if (targetContainer && targetContainer.parentNode) {
       Utils.Dom.removeChild(targetContainer.parentNode, targetContainer);
     }
+    this._sessionIdCache?.clear();
   }
 
   public isLive(): boolean {
@@ -1165,5 +1169,13 @@ export class KalturaPlayer extends FakeEventTarget {
    */
   public async getMediaCapabilities(hevcConfig?: HEVCConfigObject): Promise<MediaCapabilitiesObject> {
     return getMediaCapabilities(hevcConfig);
+  }
+
+  public setCachedUrls(urls: string[]) {
+    this._localPlayer.setCachedUrls(urls);
+  }
+
+  public get sessionIdCache() {
+    return this._sessionIdCache;
   }
 }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1171,11 +1171,11 @@ export class KalturaPlayer extends FakeEventTarget {
     return getMediaCapabilities(hevcConfig);
   }
 
-  public setCachedUrls(urls: string[]) {
+  public setCachedUrls(urls: string[]): void {
     this._localPlayer.setCachedUrls(urls);
   }
 
-  public get sessionIdCache() {
+  public get sessionIdCache(): SessionIdCache | null {
     return this._sessionIdCache;
   }
 }

--- a/tests/e2e/common/utils/kaltura-params.spec.ts
+++ b/tests/e2e/common/utils/kaltura-params.spec.ts
@@ -9,6 +9,7 @@ import {
   handleSessionId,
   updateSessionIdInUrl
 } from '../../../../src/common/utils/kaltura-params';
+import { SessionIdGenerator } from '../../../../src/common/utils/session-id-generator';
 
 class Player {
   public set sessionId(s) {
@@ -154,15 +155,15 @@ describe('handleSessionId', () => {
   });
 
   it('should update the player session id', () => {
+    SessionIdGenerator.next = '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b';
     player.config = {
       session: {
-        id: '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b'
+        id: ''
       }
     };
+    sessionIdRegex.test(player.config.session.id).should.be.false;
     handleSessionId(player, player.config);
     sessionIdRegex.test(player.config.session.id).should.be.true;
-    (player.config.session.id.indexOf('5cc03aa6-c58f-3220-b548-2a698aa54830:') > -1).should.be.true;
-    (player.config.session.id.indexOf('33e6d80e-63b3-108a-091d-ccc15998f85b') > -1).should.be.false;
   });
 });
 
@@ -174,7 +175,7 @@ describe('updateSessionIdInUrl', () => {
         id: '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b'
       }
     };
-    source.url = updateSessionIdInUrl(source.url, player.config.session.id);
+    source.url = updateSessionIdInUrl(null, source.url, player.config.session.id);
     source.url.should.be.equal('a/b/c/playmanifest/source?playSessionId=' + player.config.session.id);
   });
 
@@ -185,7 +186,7 @@ describe('updateSessionIdInUrl', () => {
         id: '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b'
       }
     };
-    source.url = updateSessionIdInUrl(source.url, player.config.session.id);
+    source.url = updateSessionIdInUrl(null, source.url, player.config.session.id);
     source.url.should.be.equal('a/b/c/playmanifest/source?a&playSessionId=' + player.config.session.id);
   });
 
@@ -198,7 +199,7 @@ describe('updateSessionIdInUrl', () => {
         id: '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b'
       }
     };
-    source.url = updateSessionIdInUrl(source.url, player.config.session.id);
+    source.url = updateSessionIdInUrl(null, source.url, player.config.session.id);
     source.url.should.be.equal('a/b/c/playmanifest/source?playSessionId=' + player.config.session.id);
   });
 
@@ -211,7 +212,7 @@ describe('updateSessionIdInUrl', () => {
         id: '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b'
       }
     };
-    source.url = updateSessionIdInUrl(source.url, player.config.session.id);
+    source.url = updateSessionIdInUrl(null, source.url, player.config.session.id);
     source.url.should.be.equal('a/b/c/playmanifest/source?a&playSessionId=' + player.config.session.id);
   });
 
@@ -224,7 +225,7 @@ describe('updateSessionIdInUrl', () => {
         id: '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b'
       }
     };
-    source.url = updateSessionIdInUrl(source.url, player.config.session.id, 'testId=');
+    source.url = updateSessionIdInUrl(null, source.url, player.config.session.id, 'testId=');
     source.url.should.be.equal('a/b/c/playmanifest/source?testId=' + player.config.session.id);
   });
 });

--- a/tests/e2e/common/utils/kaltura-params.spec.ts
+++ b/tests/e2e/common/utils/kaltura-params.spec.ts
@@ -151,7 +151,7 @@ describe('handleSessionId', () => {
 
   it('should generate add a new session id', () => {
     const nextSessionId = '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b';
-    SessionIdGenerator.next = nextSessionId;
+    SessionIdGenerator._value = nextSessionId;
     player.config = {
       session: {
         id: ''
@@ -168,7 +168,7 @@ describe('handleSessionId', () => {
 
   it('should update existing session id if not in playlist mode and there is no active source', () => {
     const nextSessionId = '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b';
-    SessionIdGenerator.next = nextSessionId;
+    SessionIdGenerator._value = nextSessionId;
     player.config = {
       session: {
         id: 'abc'
@@ -184,7 +184,7 @@ describe('handleSessionId', () => {
   });
 
   it('should not update session id if in playlist mode and there is no active entry', () => {
-    SessionIdGenerator.next = '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b';
+    SessionIdGenerator._value = '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b';
     player.config = {
       session: {
         id: 'abc'
@@ -199,7 +199,7 @@ describe('handleSessionId', () => {
   });
   it('should cache session id when generating a new id in playlist mode', () => {
     const nextSessionId = '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b';
-    SessionIdGenerator.next = nextSessionId;
+    SessionIdGenerator._value = nextSessionId;
     player.config = {
       session: {
         id: ''
@@ -224,7 +224,7 @@ describe('handleSessionId', () => {
   });
   it('should cache session id if in playlist mode and there is an active entry', () => {
     const nextSessionId = '5cc03aa6-c58f-3220-b548-2a698aa54830:33e6d80e-63b3-108a-091d-ccc15998f85b';
-    SessionIdGenerator.next = nextSessionId;
+    SessionIdGenerator._value = nextSessionId;
     player.config = {
       session: {
         id: 'abc'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,10 +5199,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.7.0.tgz#5bb0a60c1b7c2a8a3c2d1ff82e632c3c000219c3"
-  integrity sha512-utR9hKMt8GiGv7EDC8/nh8F1c4KeVGa4Wd8k6h+g2Ylks0m9//kvxvXkQnYAGJRtdql/CJC9Ur8YQ/G+kTwoiQ==
+shaka-player@4.8.11:
+  version "4.8.11"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.8.11.tgz#f67df889ac859875a2f53645840c39b67b568192"
+  integrity sha512-PXrizP6bWi6Gzjk5B7aSfBiU81di1kPd8LEBIzdaNvwINjZSMYL+lDzEWeLTIoyZCjb3l1WoJJTGLex8mD3dmg==
   dependencies:
     eme-encryption-scheme-polyfill "^2.1.1"
 


### PR DESCRIPTION
### Description of the Changes

- Add setCachedUrls API, which calls playkit (which calls dash adapter)
- Use API to prepare the next / previous playlist entries for a quick switch
- Change the behavior of session id assignment, so that the url we pass the setCachedUrls will be the same url that is later passed to adapter load()

Related PRs:
https://github.com/kaltura/playkit-js/pull/780
https://github.com/kaltura/playkit-js-dash/pull/262

Resolves FEC-13946
