### PR TITLE
fix(SUP-43445): Chapter markers does not appear in player scrubber

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -186,6 +186,7 @@ export class KalturaPlayer extends FakeEventTarget {
     const sources = Utils.Object.mergeDeep({}, playerConfig.sources, this._localPlayer.sources);
     if (playerConfig.sources.type === MediaType.VOD && this._localPlayer.sources.mediaEntryType?.toString() === MediaType.LIVE) {
       sources.id = playerConfig.sources.id;
+      sources.duration = playerConfig.sources.duration;
     }
     delete playerConfig.sources;
     Utils.Object.mergeDeep(playerConfig.session, this._localPlayer.config.session);


### PR DESCRIPTION
### Description of the Changes

**Issue:**
Chapter markers doesn't appear on the seekbar on live entry (that currently not broadcasting)

**Root cause:**
The marker displaying depend on duration promise, if duration from engine and player is not the same, the marker won't be displayed. 
souces.duration on the player contains the live duration and not the vod duration so in case the vod duration different from the live duration comparing the engine and source.duartion always returns false.

**Fix:**
If this is live entry but currently not broadcasting and vod is going to play, change the source.duration to the vod duration.

#### Resolves [SUP-43445](https://kaltura.atlassian.net/browse/SUP-43445)


[SUP-43445]: https://kaltura.atlassian.net/browse/SUP-43445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ