### PR TITLE
fix(FEC-14049): Send referrer only if supplied as iframe

### DIFF
--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -125,13 +125,8 @@ function getReferrer(): string {
   return referrer;
 }
 
-function isInUnfriendlyIframe(): boolean {
-  try {
-    // window.parent.document.URL cannot be accessed in unfriendly iframe
-    return window.parent.document.URL !== window.parent.document.URL;
-  } catch {
-    return true;
-  }
+function getOriginalRequestReferrer(): string | undefined {
+  return window.originalRequestReferrer;
 }
 
 /**
@@ -251,6 +246,6 @@ export {
   addReferrer,
   addClientTag,
   addUIConfId,
-  isInUnfriendlyIframe,
+  getOriginalRequestReferrer,
   addStartAndEndTime
 };

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -60,7 +60,7 @@ import {
   supportLegacyOptions
 } from './common/utils/setup-helpers';
 import { getDefaultRedirectOptions } from 'player-defaults';
-import { addKalturaParams, getReferrer, isInUnfriendlyIframe } from './common/utils/kaltura-params';
+import { addKalturaParams, getOriginalRequestReferrer } from './common/utils/kaltura-params';
 import { addKalturaPoster } from 'poster';
 import { RemoteSession } from './common/cast/remote-session';
 import getMediaCapabilities from './common/utils/media-capabilities';
@@ -130,11 +130,10 @@ export class KalturaPlayer extends FakeEventTarget {
     );
     this._serviceProvider = new ServiceProvider(this);
     this._cuepointManager = new CuePointManager(this);
-    const referrer = isInUnfriendlyIframe() ? getReferrer() : null;
     this._provider = new Provider(
       Utils.Object.mergeDeep(options.provider, {
         logger: { getLogger, LogLevel },
-        referrer
+        referrer: getOriginalRequestReferrer()
       }),
       __VERSION__
     );


### PR DESCRIPTION
### Description of the Changes

In case of iframe embed, the BE adds a parameter to the bundle window.originalRequestReferrer, this value will be added to api calls from the player to the backend for evaluation of access control request.
If the PR is related to an open issue please link to it.

**Issue:**
The decision when to send it with API calls to the backend needs to be based if it was supplied in origin

**Fix:**
Send the referrer to the provider only if it was supplied by the backend

#### Resolves FEC-[https://kaltura.atlassian.net/browse/FEC-14049]
