### PR TITLE
fix(FEC-14071): thumbnail requests append height, width, ks too many times

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@playkit-js/playkit-js": "0.84.12-canary.0-31130fe",
     "@playkit-js/playkit-js-dash": "1.37.0",
     "@playkit-js/playkit-js-hls": "1.32.13",
-    "@playkit-js/playkit-js-providers": "2.40.7-canary.0-46c81fb",
+    "@playkit-js/playkit-js-providers": "2.40.8-canary.0-932a336",
     "@playkit-js/playkit-js-ui": "0.79.6-canary.0-9e4f6ec",
     "hls.js": "^1.5.8",
     "shaka-player": "4.8.11"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "precommit": "yarn run build && yarn run type-check && yarn run test && yarn run lint"
   },
   "dependencies": {
-    "@playkit-js/playkit-js": "0.84.12-canary.0-31130fe",
+    "@playkit-js/playkit-js": "0.84.12",
     "@playkit-js/playkit-js-dash": "1.37.0",
     "@playkit-js/playkit-js-hls": "1.32.13",
     "@playkit-js/playkit-js-providers": "2.40.8-canary.0-932a336",

--- a/src/common/thumbnail-manager.ts
+++ b/src/common/thumbnail-manager.ts
@@ -71,11 +71,11 @@ class ThumbnailManager {
 
   private _buildKalturaThumbnailConfig = (uiConfig: UiConfig, mediaConfig: KPMediaConfig): KPThumbnailConfig => {
     const seekbarConfig = Utils.Object.getPropertyPath(uiConfig, 'components.seekbar');
-    const posterUrl = mediaConfig.sources && mediaConfig.sources.poster;
+    const rawThumbnailUrl = mediaConfig.sources && mediaConfig.sources.rawThumbnailUrl;
     const isVod = mediaConfig.sources && mediaConfig.sources.type === MediaType.VOD;
     const ks = this._player.shouldAddKs(mediaConfig) ? mediaConfig.session?.ks : '';
     const thumbnailConfig = Utils.Object.mergeDeep(DefaultThumbnailConfig, seekbarConfig);
-    const thumbsSprite = isVod ? this._getThumbSlicesUrl(posterUrl, ks, thumbnailConfig) : '';
+    const thumbsSprite = isVod ? this._getThumbSlicesUrl(rawThumbnailUrl, ks, thumbnailConfig) : '';
     return {
       thumbsSprite,
       ...thumbnailConfig

--- a/src/common/thumbnail-manager.ts
+++ b/src/common/thumbnail-manager.ts
@@ -71,8 +71,8 @@ class ThumbnailManager {
 
   private _buildKalturaThumbnailConfig = (uiConfig: UiConfig, mediaConfig: KPMediaConfig): KPThumbnailConfig => {
     const seekbarConfig = Utils.Object.getPropertyPath(uiConfig, 'components.seekbar');
-    const rawThumbnailUrl = mediaConfig.sources && mediaConfig.sources.rawThumbnailUrl;
-    const isVod = mediaConfig.sources && mediaConfig.sources.type === MediaType.VOD;
+    const rawThumbnailUrl = mediaConfig.sources?.rawThumbnailUrl;
+    const isVod = mediaConfig.sources?.type === MediaType.VOD;
     const ks = this._player.shouldAddKs(mediaConfig) ? mediaConfig.session?.ks : '';
     const thumbnailConfig = Utils.Object.mergeDeep(DefaultThumbnailConfig, seekbarConfig);
     const thumbsSprite = isVod ? this._getThumbSlicesUrl(rawThumbnailUrl, ks, thumbnailConfig) : '';

--- a/src/ovp/poster.ts
+++ b/src/ovp/poster.ts
@@ -22,7 +22,8 @@ function addKalturaPoster(
   const playerWidth = dimensions.width;
   const playerHeight = dimensions.height;
   if (typeof playerPoster === 'string' && THUMBNAIL_REGEX.test(playerPoster) && playerPoster === mediaConfigPoster) {
-    playerSources.poster = `${playerPoster}/height/${playerHeight}/width/${playerWidth}${ks ? `/ks/${ks}` : ''}`;
+    const rawThumbnailUrl = mediaSources.rawThumbnailUrl;
+    playerSources.poster = `${rawThumbnailUrl}/height/${playerHeight}/width/${playerWidth}${ks ? `/ks/${ks}` : ''}`;
   }
   mediaSources.poster = playerSources.poster || '';
 }

--- a/src/ovp/poster.ts
+++ b/src/ovp/poster.ts
@@ -22,7 +22,12 @@ function addKalturaPoster(
   const playerWidth = dimensions.width;
   const playerHeight = dimensions.height;
   const rawThumbnailUrl = mediaSources.rawThumbnailUrl;
-  if (typeof playerPoster === 'string' && THUMBNAIL_REGEX.test(playerPoster) && playerPoster === mediaConfigPoster && typeof rawThumbnailUrl === 'string') {
+  if (
+    typeof playerPoster === 'string' &&
+    THUMBNAIL_REGEX.test(playerPoster) &&
+    playerPoster === mediaConfigPoster &&
+    typeof rawThumbnailUrl === 'string'
+  ) {
     playerSources.poster = `${rawThumbnailUrl}/height/${playerHeight}/width/${playerWidth}${ks ? `/ks/${ks}` : ''}`;
   }
   mediaSources.poster = playerSources.poster || '';

--- a/src/ovp/poster.ts
+++ b/src/ovp/poster.ts
@@ -21,8 +21,8 @@ function addKalturaPoster(
   const mediaConfigPoster = mediaSources.poster;
   const playerWidth = dimensions.width;
   const playerHeight = dimensions.height;
-  if (typeof playerPoster === 'string' && THUMBNAIL_REGEX.test(playerPoster) && playerPoster === mediaConfigPoster) {
-    const rawThumbnailUrl = mediaSources.rawThumbnailUrl;
+  const rawThumbnailUrl = mediaSources.rawThumbnailUrl;
+  if (typeof playerPoster === 'string' && THUMBNAIL_REGEX.test(playerPoster) && playerPoster === mediaConfigPoster && typeof rawThumbnailUrl === 'string') {
     playerSources.poster = `${rawThumbnailUrl}/height/${playerHeight}/width/${playerWidth}${ks ? `/ks/${ks}` : ''}`;
   }
   mediaSources.poster = playerSources.poster || '';

--- a/tests/e2e/common/thumbnail-manager.spec.ts
+++ b/tests/e2e/common/thumbnail-manager.spec.ts
@@ -31,6 +31,7 @@ describe('ThumbnailManager', () => {
     fakeMediaConfig = {
       sources: {
         poster: '//my-thumb-service.com/p/1/thumbnail/entry_id/2/version/3',
+        rawThumbnailUrl: '//my-thumb-service.com/p/1/thumbnail/entry_id/2/version/3',
         type: MediaType.VOD
       },
       session: {
@@ -69,13 +70,13 @@ describe('ThumbnailManager', () => {
   });
 
   it('should get empty thumbnail slices url for non string given', () => {
-    fakeMediaConfig.sources.poster = null;
+    fakeMediaConfig.sources.rawThumbnailUrl = null;
     thumbnailManager = new ThumbnailManager(fakePlayer, fakePlayer.config.ui, fakeMediaConfig);
     thumbnailManager.getKalturaThumbnailConfig().thumbsSprite.should.equals('');
   });
 
   it('should get empty thumbnail slices url for non valid string given', () => {
-    fakeMediaConfig.sources.poster = '//my-thumb-service.com/p/1/entry_id/2/version/3';
+    fakeMediaConfig.sources.rawThumbnailUrl = '//my-thumb-service.com/p/1/entry_id/2/version/3';
     thumbnailManager = new ThumbnailManager(fakePlayer, fakePlayer.config.ui, fakeMediaConfig);
     thumbnailManager.getKalturaThumbnailConfig().thumbsSprite.should.equals('');
   });
@@ -100,7 +101,7 @@ describe('ThumbnailManager', () => {
   });
 
   it('should return thumbnail from core player', () => {
-    fakeMediaConfig.sources.poster = null;
+    fakeMediaConfig.sources.rawThumbnailUrl = null;
     thumbnailManager = new ThumbnailManager(fakePlayer, fakePlayer.config.ui, fakeMediaConfig);
     const spy = sandbox.spy(fakePlayer._localPlayer, 'getThumbnail');
     thumbnailManager.getThumbnail(100);

--- a/tests/e2e/ovp/poster.spec.js
+++ b/tests/e2e/ovp/poster.spec.js
@@ -44,7 +44,7 @@ describe('addKalturaPoster', () => {
   });
 
   it('should append ks to kaltura poster', () => {
-    const mediaSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2', rawThumbnailUrl: '/p/1091/thumbnail/entry_id/0_wifqaipd/2'};
+    const mediaSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2', rawThumbnailUrl: '/p/1091/thumbnail/entry_id/0_wifqaipd/2' };
     const playerSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2' };
     const ks = '123';
     addKalturaPoster(playerSources, mediaSources, { width: 640, height: 360 }, ks);

--- a/tests/e2e/ovp/poster.spec.js
+++ b/tests/e2e/ovp/poster.spec.js
@@ -8,7 +8,7 @@ const targetId = 'player-placeholder_ovp/poster.spec';
 
 describe('addKalturaPoster', () => {
   it('should append width and height to kaltura poster', () => {
-    const mediaSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2' };
+    const mediaSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2', rawThumbnailUrl: '/p/1091/thumbnail/entry_id/0_wifqaipd/2' };
     const playerSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2' };
     addKalturaPoster(playerSources, mediaSources, { width: 640, height: 360 });
     playerSources.poster.should.equal('/p/1091/thumbnail/entry_id/0_wifqaipd/2/height/360/width/640');
@@ -44,7 +44,7 @@ describe('addKalturaPoster', () => {
   });
 
   it('should append ks to kaltura poster', () => {
-    const mediaSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2' };
+    const mediaSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2', rawThumbnailUrl: '/p/1091/thumbnail/entry_id/0_wifqaipd/2'};
     const playerSources = { poster: '/p/1091/thumbnail/entry_id/0_wifqaipd/2' };
     const ks = '123';
     addKalturaPoster(playerSources, mediaSources, { width: 640, height: 360 }, ks);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,10 +1182,10 @@
   resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.32.13.tgz#d0c9f42f9055b6a454aa1e2a42a8bf6610c43087"
   integrity sha512-d16JZrJBXqXwTyY0PRuiO2XpxjIW6QnYw1/PpipWr/IMpC8dVRhjvpz9rARbs5sM4C5QSLZS6rGBwWK+DbRIRg==
 
-"@playkit-js/playkit-js-providers@2.40.7-canary.0-46c81fb":
-  version "2.40.7-canary.0-46c81fb"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.40.7-canary.0-46c81fb.tgz#559f6d3060d05667a33c512b58f4f5d40aed0524"
-  integrity sha512-rZ75qPUVzXwrVeUHejXcAGVYSESQAO6R7LScFL88VFF/L2NLnMOqvNotlm5xbuBA7T6uQlAcaMD1NoTsTzQqyg==
+"@playkit-js/playkit-js-providers@2.40.8-canary.0-932a336":
+  version "2.40.8-canary.0-932a336"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.40.8-canary.0-932a336.tgz#23d32e72a45e86403ed19ba8fd90d664178672da"
+  integrity sha512-0XBbzGqHjJQHYTXh1omS6lfMAy69rBe9PvK0lSznEvcMhRPLq4cTBfJ3EMpCxknb5fGRvtfDdbUHoktqurshQA==
 
 "@playkit-js/playkit-js-ui@0.79.6-canary.0-9e4f6ec":
   version "0.79.6-canary.0-9e4f6ec"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,10 +1197,10 @@
     react-redux "7.2.1"
     redux "4.0.5"
 
-"@playkit-js/playkit-js@0.84.12-canary.0-31130fe":
-  version "0.84.12-canary.0-31130fe"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.12-canary.0-31130fe.tgz#360d5ab1475b853b965713ea75caec8613a33956"
-  integrity sha512-MXdNHalHGBxFFH2OKDKXYjSksy4o0Vqfit37z8T8r7O3jPdbDIzr4MzU0e9opaGHcFj/F7kx0EKpd2aH2AylIA==
+"@playkit-js/playkit-js@0.84.12":
+  version "0.84.12"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js/-/playkit-js-0.84.12.tgz#0b0dc228a21db614bd0e2b6025d04db5f4834a3a"
+  integrity sha512-ndgjPBRWRdvNoj8/Pu1h76ZzJkJlcbGI/aShbYAuop8HoFYheC/Felgu/TQbpBH87YnWX8Ev6s/f8w3hVptznQ==
   dependencies:
     js-logger "^1.6.0"
     ua-parser-js "^1.0.36"


### PR DESCRIPTION
### Description of the Changes

bugfix

**Issue:**
when building `poster` and `sprite` URLs, we are using the `poster` as the base url and then appending params to it (height, width, ks). But, when poster has already been manipulated and we try to build it again, we re-append the params.

**Fix:**
use `rawThumbnailUrl` as the base url to build the urls.

related PR: https://github.com/kaltura/playkit-js-providers/pull/243

#### Resolves FEC-14071
