### PR TITLE
fix(FEC-14093): rapt is not loading on latest player

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -122,13 +122,13 @@ export class KalturaPlayer extends FakeEventTarget {
     this._localPlayer = loadPlayer(noSourcesOptions);
     this._controllerProvider = new ControllerProvider(this._pluginManager);
     this._viewabilityManager = new ViewabilityManager(this.config.viewability);
+    this._serviceProvider = new ServiceProvider(this);
     this._uiWrapper = new UIWrapper(
       this,
       Utils.Object.mergeDeep(options, {
         ui: { logger: { getLogger, LogLevel } }
       })
     );
-    this._serviceProvider = new ServiceProvider(this);
     this._cuepointManager = new CuePointManager(this);
     this._provider = new Provider(
       Utils.Object.mergeDeep(options.provider, {


### PR DESCRIPTION
### Description of the Changes

**bugfix - regression**

**Issue:**
since the latest player changes, while loading rapt media, the player is not being displayed on the page (blank space).
- as part of the latest changes in bottom-bar comp, we register a new service in the constructor, which uses the `serviceProvider` member of kaltura player
- rapt renders the bottom-bar component before kaltura-player finished initializing - `serviceProvider` is `undefined`, which causes a runtime error

**Fix:**
move `serviceProvider` initialization before initializing the ui.

#### Resolves FEC-14093
