### PR TITLE
fix(SUP-44085): Two different players on the same page

### DIFF
--- a/src/common/ui-wrapper.ts
+++ b/src/common/ui-wrapper.ts
@@ -26,8 +26,8 @@ class UIWrapper {
       }
     } else {
       this._uiManager = new UIManager(player, config);
-      if (config.customPreset || window.kalturaCustomPreset) {
-        this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPreset);
+      if (config.customPreset || window.kalturaCustomPresetMap[config.targetId]) {
+        this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPresetMap[config.targetId]);
       } else {
         this._uiManager.buildDefaultUI();
       }

--- a/src/common/ui-wrapper.ts
+++ b/src/common/ui-wrapper.ts
@@ -26,7 +26,7 @@ class UIWrapper {
       }
     } else {
       this._uiManager = new UIManager(player, config);
-      if (config.customPreset || window.kalturaCustomPresetMap[config.targetId]) {
+      if (config.customPreset || (window.kalturaCustomPresetMap && window.kalturaCustomPresetMap[config.targetId])) {
         this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPresetMap[config.targetId]);
       } else {
         this._uiManager.buildDefaultUI();

--- a/src/common/ui-wrapper.ts
+++ b/src/common/ui-wrapper.ts
@@ -27,7 +27,7 @@ class UIWrapper {
     } else {
       this._uiManager = new UIManager(player, config);
       if (config.customPreset || (window.kalturaCustomPresetMap && window.kalturaCustomPresetMap[config.targetId])) {
-        this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPresetMap[config.targetId]['audioPreset']);
+        this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPresetMap[config.targetId]['audioPlayer']);
       } else {
         this._uiManager.buildDefaultUI();
       }

--- a/src/common/ui-wrapper.ts
+++ b/src/common/ui-wrapper.ts
@@ -27,7 +27,7 @@ class UIWrapper {
     } else {
       this._uiManager = new UIManager(player, config);
       if (config.customPreset || (window.kalturaCustomPresetMap && window.kalturaCustomPresetMap[config.targetId])) {
-        this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPresetMap[config.targetId]);
+        this._uiManager.buildCustomUI(config.customPreset || window.kalturaCustomPresetMap[config.targetId]['audioPreset']);
       } else {
         this._uiManager.buildDefaultUI();
       }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -426,6 +426,10 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.getActiveTracks();
   }
 
+  public changeChildQuality(track: any | string): void {
+    this._localPlayer.changeChildQuality(track);
+  }
+
   public selectTrack(track: Track): void {
     this._localPlayer.selectTrack(track);
   }
@@ -832,15 +836,17 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   private _addAudioPreset(options: Partial<KalturaPlayerConfig>): void {
-    if (options.plugins?.audioPlayer) {
-      if (!window.kalturaCustomPresetMap) {
-        window.kalturaCustomPresetMap = {};
+    Object.keys(options.plugins).forEach((plugin) => {
+      if (window.kalturaCustomPreset[plugin]) {
+        if (!window.kalturaCustomPresetMap) {
+          window.kalturaCustomPresetMap = {};
+        }
+        if (!window.kalturaCustomPresetMap[options.ui!.targetId]) {
+          window.kalturaCustomPresetMap[options.ui!.targetId] = {};
+        }
+        window.kalturaCustomPresetMap[options.ui!.targetId][plugin] = window.kalturaCustomPreset[plugin];
       }
-      if (!window.kalturaCustomPresetMap[options.ui!.targetId]) {
-        window.kalturaCustomPresetMap[options.ui!.targetId] = {};
-      }
-      window.kalturaCustomPresetMap[options.ui!.targetId]['audioPreset'] = window.kalturaCustomPreset;
-    }
+    });
   }
 
   private _configureInformationForDevice(mediaConfig: KPMediaConfig): void {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -831,7 +831,7 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.Error;
   }
 
-  private _addAudioPreset(options: Partial<KalturaPlayerConfig>) {
+  private _addAudioPreset(options: Partial<KalturaPlayerConfig>): void {
     if (options.plugins?.audioPlayer) {
       if (!window.kalturaCustomPresetMap) {
         window.kalturaCustomPresetMap = {};

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -835,7 +835,12 @@ export class KalturaPlayer extends FakeEventTarget {
     if (options.plugins) {
       Object.keys(options.plugins).forEach((plugin) => {
         if (window.kalturaCustomPreset && window.kalturaCustomPreset[plugin]) {
-          window.kalturaCustomPresetMap[options.ui!.targetId] = window.kalturaCustomPresetMap[options.ui!.targetId] || {};
+          if (!window.kalturaCustomPresetMap) {
+            window.kalturaCustomPresetMap = {};
+          }
+          if (!window.kalturaCustomPresetMap[options.ui!.targetId]) {
+            window.kalturaCustomPresetMap[options.ui!.targetId] = {};
+          }
           window.kalturaCustomPresetMap[options.ui!.targetId][plugin] = window.kalturaCustomPreset[plugin];
         }
       });

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -834,7 +834,7 @@ export class KalturaPlayer extends FakeEventTarget {
   private _addCustomPreset(options: Partial<KalturaPlayerConfig>): void {
     if (options.plugins) {
       Object.keys(options.plugins).forEach((plugin) => {
-        if (window.kalturaCustomPreset[plugin]) {
+        if (window.kalturaCustomPreset && window.kalturaCustomPreset[plugin]) {
           window.kalturaCustomPresetMap[options.ui!.targetId] = window.kalturaCustomPresetMap[options.ui!.targetId] || {};
           window.kalturaCustomPresetMap[options.ui!.targetId][plugin] = window.kalturaCustomPreset[plugin];
         }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -832,11 +832,11 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   private _addAudioPreset(options: Partial<KalturaPlayerConfig>) {
-    if (options.plugins.audioPlayer) {
+    if (options.plugins?.audioPlayer) {
       if (!window.kalturaCustomPresetMap) {
         window.kalturaCustomPresetMap = {};
       }
-      window.kalturaCustomPresetMap[options.ui.targetId] = window.kalturaCustomPreset;
+      window.kalturaCustomPresetMap[options.ui?.targetId] = window.kalturaCustomPreset;
     }
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -115,7 +115,7 @@ export class KalturaPlayer extends FakeEventTarget {
     this._sessionIdCache = new SessionIdCache();
     this._configEvaluator = new ConfigEvaluator();
     this._configEvaluator.evaluatePluginsConfig(plugins, options);
-    this._addAudioPreset(options);
+    this._addCustomPreset(options);
     this._playbackStart = false;
     const noSourcesOptions = Utils.Object.mergeDeep({}, options);
     delete noSourcesOptions.plugins;
@@ -831,16 +831,11 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.Error;
   }
 
-  private _addAudioPreset(options: Partial<KalturaPlayerConfig>): void {
+  private _addCustomPreset(options: Partial<KalturaPlayerConfig>): void {
     if (options.plugins) {
       Object.keys(options.plugins).forEach((plugin) => {
         if (window.kalturaCustomPreset[plugin]) {
-          if (!window.kalturaCustomPresetMap) {
-            window.kalturaCustomPresetMap = {};
-          }
-          if (!window.kalturaCustomPresetMap[options.ui!.targetId]) {
-            window.kalturaCustomPresetMap[options.ui!.targetId] = {};
-          }
+          window.kalturaCustomPresetMap[options.ui!.targetId] = window.kalturaCustomPresetMap[options.ui!.targetId] || {};
           window.kalturaCustomPresetMap[options.ui!.targetId][plugin] = window.kalturaCustomPreset[plugin];
         }
       });

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -426,10 +426,6 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.getActiveTracks();
   }
 
-  public changeChildQuality(track: any | string): void {
-    this._localPlayer.changeChildQuality(track);
-  }
-
   public selectTrack(track: Track): void {
     this._localPlayer.selectTrack(track);
   }
@@ -836,17 +832,19 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   private _addAudioPreset(options: Partial<KalturaPlayerConfig>): void {
-    Object.keys(options.plugins).forEach((plugin) => {
-      if (window.kalturaCustomPreset[plugin]) {
-        if (!window.kalturaCustomPresetMap) {
-          window.kalturaCustomPresetMap = {};
+    if (options.plugins) {
+      Object.keys(options.plugins).forEach((plugin) => {
+        if (window.kalturaCustomPreset[plugin]) {
+          if (!window.kalturaCustomPresetMap) {
+            window.kalturaCustomPresetMap = {};
+          }
+          if (!window.kalturaCustomPresetMap[options.ui!.targetId]) {
+            window.kalturaCustomPresetMap[options.ui!.targetId] = {};
+          }
+          window.kalturaCustomPresetMap[options.ui!.targetId][plugin] = window.kalturaCustomPreset[plugin];
         }
-        if (!window.kalturaCustomPresetMap[options.ui!.targetId]) {
-          window.kalturaCustomPresetMap[options.ui!.targetId] = {};
-        }
-        window.kalturaCustomPresetMap[options.ui!.targetId][plugin] = window.kalturaCustomPreset[plugin];
-      }
-    });
+      });
+    }
   }
 
   private _configureInformationForDevice(mediaConfig: KPMediaConfig): void {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -836,7 +836,7 @@ export class KalturaPlayer extends FakeEventTarget {
       if (!window.kalturaCustomPresetMap) {
         window.kalturaCustomPresetMap = {};
       }
-      window.kalturaCustomPresetMap[options.ui?.targetId] = window.kalturaCustomPreset;
+      window.kalturaCustomPresetMap[options.ui!.targetId] = window.kalturaCustomPreset;
     }
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -836,7 +836,10 @@ export class KalturaPlayer extends FakeEventTarget {
       if (!window.kalturaCustomPresetMap) {
         window.kalturaCustomPresetMap = {};
       }
-      window.kalturaCustomPresetMap[options.ui!.targetId] = window.kalturaCustomPreset;
+      if (!window.kalturaCustomPresetMap[options.ui!.targetId]) {
+        window.kalturaCustomPresetMap[options.ui!.targetId] = {};
+      }
+      window.kalturaCustomPresetMap[options.ui!.targetId]['audioPreset'] = window.kalturaCustomPreset;
     }
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -115,6 +115,7 @@ export class KalturaPlayer extends FakeEventTarget {
     this._sessionIdCache = new SessionIdCache();
     this._configEvaluator = new ConfigEvaluator();
     this._configEvaluator.evaluatePluginsConfig(plugins, options);
+    this._addAudioPreset(options);
     this._playbackStart = false;
     const noSourcesOptions = Utils.Object.mergeDeep({}, options);
     delete noSourcesOptions.plugins;
@@ -828,6 +829,15 @@ export class KalturaPlayer extends FakeEventTarget {
 
   public get Error(): typeof Error {
     return this._localPlayer.Error;
+  }
+
+  private _addAudioPreset(options: Partial<KalturaPlayerConfig>) {
+    if (options.plugins.audioPlayer) {
+      if (!window.kalturaCustomPresetMap) {
+        window.kalturaCustomPresetMap = {};
+      }
+      window.kalturaCustomPresetMap[options.ui.targetId] = window.kalturaCustomPreset;
+    }
   }
 
   private _configureInformationForDevice(mediaConfig: KPMediaConfig): void {

--- a/src/types/global/globals.d.ts
+++ b/src/types/global/globals.d.ts
@@ -1,6 +1,7 @@
 // globals.d.ts
 declare var __kalturaplayerdata: any;
 declare var kalturaCustomPreset: any;
+declare var kalturaCustomPresetMap: any;
 declare var DEBUG_KALTURA_PLAYER: boolean;
 declare var __NAME__: string;
 declare var __VERSION__: string;


### PR DESCRIPTION
### Description of the Changes

**Issue:**
when there 2 or more different players on one page, video player is not loaded fine

**Fix:**
add the audio preset on new global variable according to the player targetId

pr related - https://github.com/kaltura/playkit-js-audio-player/pull/32/files

#### Resolves [SUP-44085](https://kaltura.atlassian.net/browse/SUP-44085)


[SUP-44085]: https://kaltura.atlassian.net/browse/SUP-44085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ