### PR TITLE
fix(SUP-38407): [GaTech] [Multistream - V7 Player] Child entries not loading high quality flavor assets

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -438,7 +438,7 @@ export class KalturaPlayer extends FakeEventTarget {
     this._localPlayer.showTextTrack();
   }
 
-  public changeChildQuality(track: any | string): void {
+  public changeQuality(track: any | string): void {
     this._localPlayer.changeChildQuality(track);
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -439,7 +439,7 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   public changeQuality(track: any | string): void {
-    this._localPlayer.changeChildQuality(track);
+    this._localPlayer.changeQuality(track);
   }
 
   public enableAdaptiveBitrate(): void {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -438,6 +438,10 @@ export class KalturaPlayer extends FakeEventTarget {
     this._localPlayer.showTextTrack();
   }
 
+  public changeChildQuality(track: any | string): void {
+    this._localPlayer.changeChildQuality(track);
+  }
+
   public enableAdaptiveBitrate(): void {
     this._localPlayer.enableAdaptiveBitrate();
   }


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

export changeChildQuality function

part of - https://github.com/kaltura/playkit-js/pull/793/files, https://github.com/kaltura/playkit-js-dual-screen/pull/155

#### Resolves [SUP-38407](https://kaltura.atlassian.net/browse/SUP-38407)


[SUP-38407]: https://kaltura.atlassian.net/browse/SUP-38407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ