### PR TITLE
feat(FEC-14189): Ingore referrer kaltura.com in friendly iframe 

### DIFF
--- a/src/common/utils/kaltura-params.ts
+++ b/src/common/utils/kaltura-params.ts
@@ -115,6 +115,10 @@ function getReferrer(): string {
   let referrer;
   try {
     referrer = window.parent.document.URL;
+    //Ignore referrer from friendly iframe that contains kaltura.com
+    if (referrer.toLowerCase().includes('kaltura.com')) {
+      throw new Error('ignoring referrer:' + referrer);
+    }
   } catch (e) {
     // unfriendly iframe
 

--- a/tests/e2e/common/plugin/plugins-config.spec.ts
+++ b/tests/e2e/common/plugin/plugins-config.spec.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line  @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { ConfigEvaluator, getEncodedReferrer } from '../../../../src/common/plugins';
-import { getReferrer } from '../../../../src/common/utils/kaltura-params';
 
 const sandbox = sinon.createSandbox();
 
@@ -152,41 +151,5 @@ describe('getEncodedReferrer', () => {
     });
     window.parent.document.URL.should.be.equal('http://localhost:3000/?debugKalturaPlayer');
     getEncodedReferrer().should.be.equal('http%3A%2F%2Flocalhost%3A3000%2F%3FdebugKalturaPlayer');
-  });
-});
-
-describe('testReferrerLogic', () => {
-  before(() => {
-    window.originalRequestReferrer = undefined;
-  });
-
-  it('no referrer on parent', () => {
-    sandbox.stub(window, 'parent').get(() => undefined);
-    sandbox.stub(document, 'referrer').get(() => 'localRef');
-    getReferrer().should.equal('localRef');
-  });
-
-  it('referrer on parent', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : 'parentRef'}}});
-    getReferrer().should.equal('parentRef');
-  });
-
-  it('no referrer on parent and backend supplied referrer', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : undefined}}});
-    sandbox.stub(window, 'originalRequestReferrer').get(() => "backendRef");
-    getReferrer().should.equal('backendRef');
-  });
-
-  it('if parent referrer contains kaltura.com and backend supplied referrer', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : 'bla.kaltura.com'}}});
-    sandbox.stub(window, 'originalRequestReferrer').get(() => "test-kaltura.com");
-    getReferrer().should.equal('test-kaltura.com');
-  });
-
-  it('if parent referrer contains kaltura.com and backend does not supplied referrer', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : 'bla.kaltura.com'}}});
-    sandbox.stub(document, 'referrer').get(() => 'localRef');
-    sandbox.stub(window, 'originalRequestReferrer').get(() => undefined);
-    getReferrer().should.equal('localRef');
   });
 });

--- a/tests/e2e/common/utils/kaltura-params.spec.ts
+++ b/tests/e2e/common/utils/kaltura-params.spec.ts
@@ -391,24 +391,32 @@ describe('testReferrerLogic', () => {
   });
 
   it('referrer on parent', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : 'parentRef'}}});
+    sandbox.stub(window, 'parent').get(() => {
+      return { document: { URL: 'parentRef' } };
+    });
     getReferrer().should.equal('parentRef');
   });
 
   it('no referrer on parent and backend supplied referrer', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : undefined}}});
-    sandbox.stub(window, 'originalRequestReferrer').get(() => "backendRef");
+    sandbox.stub(window, 'parent').get(() => {
+      return { document: { URL: undefined } };
+    });
+    sandbox.stub(window, 'originalRequestReferrer').get(() => 'backendRef');
     getReferrer().should.equal('backendRef');
   });
 
   it('if parent referrer contains kaltura.com and backend supplied referrer', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : 'bla.kaltura.com'}}});
-    sandbox.stub(window, 'originalRequestReferrer').get(() => "test-kaltura.com");
+    sandbox.stub(window, 'parent').get(() => {
+      return { document: { URL: 'bla.kaltura.com' } };
+    });
+    sandbox.stub(window, 'originalRequestReferrer').get(() => 'test-kaltura.com');
     getReferrer().should.equal('test-kaltura.com');
   });
 
   it('if parent referrer contains kaltura.com and backend does not supplied referrer', () => {
-    sandbox.stub(window, 'parent').get(() => {return { document : {URL : 'bla.kaltura.com'}}});
+    sandbox.stub(window, 'parent').get(() => {
+      return { document: { URL: 'bla.kaltura.com' } };
+    });
     sandbox.stub(document, 'referrer').get(() => 'localRef');
     sandbox.stub(window, 'originalRequestReferrer').get(() => undefined);
     getReferrer().should.equal('localRef');


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**
When open player iframe on new tab, its referrer is kaltura.com, in such case site based access control will reject it.

**Fix:**
If we are in friendly iframe and domain is kaltura.com, we ignore it and return the domain that the backend embed inside the iframe bundle

#### Resolves FEC-14189
