### PR TITLE
fix(SUP-37490): Align captions with clipTo/SeekFrom Values in PlayManifest

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1207,7 +1207,7 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._sessionIdCache;
   }
 
-  private handleSourceTimeRangeUpdate(seekFrom: number | undefined, clipTo: number | undefined) {
+  private handleSourceTimeRangeUpdate(seekFrom: number | undefined, clipTo: number | undefined): void {
     let ignoreManifestTextTracks = false;
 
     if (typeof seekFrom === 'number') {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1212,11 +1212,11 @@ export class KalturaPlayer extends FakeEventTarget {
 
     if (typeof seekFrom === 'number') {
       ignoreManifestTextTracks = true;
-      this._localPlayer.setCuesTimeRangeStart(seekFrom);
+      this._localPlayer.setSeekFrom(seekFrom);
     }
     if (typeof clipTo === 'number') {
       ignoreManifestTextTracks = true;
-      this._localPlayer.setCuesTimeRangeEnd(clipTo);
+      this._localPlayer.setClipTo(clipTo);
     }
     if (ignoreManifestTextTracks) {
       // TODO move this into adapters

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -162,6 +162,38 @@ export class KalturaPlayer extends FakeEventTarget {
     this.reset();
     this._localPlayer.loadingMedia = true;
     this._uiWrapper.setLoadingSpinnerState(true);
+
+    let seekFrom, clipTo;
+
+    if (!isNaN(mediaOptions?.seekFrom)) {
+      seekFrom = mediaOptions.seekFrom;
+      this._localPlayer.setCuesTimeRangeStart(seekFrom);
+    }
+    if (!isNaN(mediaOptions?.clipTo)) {
+      clipTo = mediaOptions.clipTo;
+      this._localPlayer.setCuesTimeRangeEnd(clipTo);
+    }
+
+    if (seekFrom !== undefined || clipTo !== undefined) {
+      // TODO move this into adapters
+      this.configure({
+        playback: {
+          options: {
+            html5: {
+              hls: {
+                subtitleTrackController: null
+              },
+              dash: {
+                manifest: {
+                  disableText: true
+                }
+              }
+            }
+          }
+        }
+      } as any);
+    }
+
     try {
       const providerMediaConfig: ProviderMediaConfigObject = await this._provider.getMediaConfig(mediaInfo);
       const mediaConfig = Utils.Object.copyDeep(providerMediaConfig);

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -162,37 +162,8 @@ export class KalturaPlayer extends FakeEventTarget {
     this.reset();
     this._localPlayer.loadingMedia = true;
     this._uiWrapper.setLoadingSpinnerState(true);
-
-    let seekFrom, clipTo;
-
-    if (!isNaN(mediaOptions?.seekFrom)) {
-      seekFrom = mediaOptions.seekFrom;
-      this._localPlayer.setCuesTimeRangeStart(seekFrom);
-    }
-    if (!isNaN(mediaOptions?.clipTo)) {
-      clipTo = mediaOptions.clipTo;
-      this._localPlayer.setCuesTimeRangeEnd(clipTo);
-    }
-
-    if (seekFrom !== undefined || clipTo !== undefined) {
-      // TODO move this into adapters
-      this.configure({
-        playback: {
-          options: {
-            html5: {
-              hls: {
-                subtitleTrackController: null
-              },
-              dash: {
-                manifest: {
-                  disableText: true
-                }
-              }
-            }
-          }
-        }
-      } as any);
-    }
+    // TODO update sources config types in provider
+    this.handleSourceTimeRangeUpdate((mediaOptions as any)?.seekFrom, (mediaOptions as any)?.clipTo);
 
     try {
       const providerMediaConfig: ProviderMediaConfigObject = await this._provider.getMediaConfig(mediaInfo);
@@ -1234,5 +1205,37 @@ export class KalturaPlayer extends FakeEventTarget {
 
   public get sessionIdCache(): SessionIdCache | null {
     return this._sessionIdCache;
+  }
+
+  private handleSourceTimeRangeUpdate(seekFrom: number | undefined, clipTo: number | undefined) {
+    let ignoreManifestTextTracks = false;
+
+    if (typeof seekFrom === 'number') {
+      ignoreManifestTextTracks = true;
+      this._localPlayer.setCuesTimeRangeStart(seekFrom);
+    }
+    if (typeof clipTo === 'number') {
+      ignoreManifestTextTracks = true;
+      this._localPlayer.setCuesTimeRangeEnd(clipTo);
+    }
+    if (ignoreManifestTextTracks) {
+      // TODO move this into adapters
+      this.configure({
+        playback: {
+          options: {
+            html5: {
+              hls: {
+                subtitleTrackController: null
+              },
+              dash: {
+                manifest: {
+                  disableText: true
+                }
+              }
+            }
+          }
+        }
+      } as any);
+    }
   }
 }


### PR DESCRIPTION
### Description of the Changes

If sources.seekFrom or sources.clipTo is set
- Ignore the manifest text tracks, which will cause the playkit player to add external text tracks according to the getPlaybackContext captions metadata
- Pass seekFrom and clipTo to the playkit player so that it will filter and shift the caption cues according to the new time range

Related PR: https://github.com/kaltura/playkit-js/pull/798
