### PR TITLE
fix(SUP-37490): Align captions with clipTo/SeekFrom Values in PlayManifest

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -162,9 +162,6 @@ export class KalturaPlayer extends FakeEventTarget {
     this.reset();
     this._localPlayer.loadingMedia = true;
     this._uiWrapper.setLoadingSpinnerState(true);
-    // TODO update sources config types in provider
-    this.handleSourceTimeRangeUpdate((mediaOptions as any)?.seekFrom, (mediaOptions as any)?.clipTo);
-
     try {
       const providerMediaConfig: ProviderMediaConfigObject = await this._provider.getMediaConfig(mediaInfo);
       const mediaConfig = Utils.Object.copyDeep(providerMediaConfig);
@@ -271,6 +268,7 @@ export class KalturaPlayer extends FakeEventTarget {
     delete localPlayerConfig.plugins;
     if (localPlayerConfig.sources) {
       const { sources } = localPlayerConfig;
+      this.handleSourcesTimeRangeUpdate(sources.seekFrom, sources.clipTo);
       delete localPlayerConfig.sources;
       this._localPlayer.configure(localPlayerConfig);
       this._localPlayer.setSources(sources || {});
@@ -1207,7 +1205,7 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._sessionIdCache;
   }
 
-  private handleSourceTimeRangeUpdate(seekFrom: number | undefined, clipTo: number | undefined): void {
+  private handleSourcesTimeRangeUpdate(seekFrom: number | undefined, clipTo: number | undefined): void {
     let ignoreManifestTextTracks = false;
 
     if (typeof seekFrom === 'number') {


### PR DESCRIPTION
### Description of the Changes

Move the processing of seekFrom and clipTo from loadMedia() into configure(), where instead of using values from loadMedia mediaOptions arguments, we can use the combined sources config set by merging mediaOptions values with sources config values (which is where the kalturaSeekFrom, kalturaClipTo values from URL are set).

Which means that:
- If the values are set ONLY by URL, we use those values to clip captions.

- If the values are set ONLY by loadMedia, we use those values.

- If a value is set by URL and ALSO by mediaOptions, we prefer the value set by configuration over the value set by mediaOptions (which actually seems to be a bug because [it should be the opposite](https://github.com/kaltura/kaltura-player-js/pull/880), but this is the current behavior). So for example, kalturaSeekFrom=30 in URL would override the seekFrom value set by loadMedia(..., { seekFrom: 10, clipTo: 50 }).

- If one value is set by URL and one is set by mediaOptions 
(i.e. inside the page https://...?kalturaSeekFrom=20) we call loadMedia(..., {clipTo: 60}), 
we use the combined values {seekFrom: 20, clipTo: 60} together to clip the captions.