### PR TITLE
fix(SUP-45003): [IKEA Ingka] - past scheduled embedded entries will show a wrong error message for V7 player

### DIFF
--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -3,20 +3,28 @@ import { Error } from '@playkit-js/playkit-js';
 const isBackEndError = (error: Error): boolean => error.category === 2;
 const isBlockAction = (error: Error): boolean => error.code === 2001;
 const isMediaNotReady = (error: Error): boolean => error.code === 2002;
+const isScheduledRestrictedCode = (error: Error): boolean => error.code === 2003;
 const isGeolocationRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'COUNTRY_RESTRICTED';
 const isSessionRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SESSION_RESTRICTED';
 const isIPRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'IP_RESTRICTED';
+const isSitedRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SITE_RESTRICTED';
+const isScheduledRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SCHEDULED_RESTRICTED';
 
 const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSessionRestricted(error);
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);
 const isMediaNotReadyError = (error: Error): boolean => isBackEndError(error) && isMediaNotReady(error);
 const isIPRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isIPRestricted(error);
+const isSitedRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSitedRestricted(error);
+const isScheduledRestrictedError = (error: Error): boolean =>
+  isBackEndError(error) && isScheduledRestrictedCode(error) && isScheduledRestricted(error);
 
 const conditionsToErrors: any[] = [
   [isSessionRestrictedError, Error.Category.MEDIA_UNAVAILABLE],
   [isGeolocationError, Error.Category.GEO_LOCATION],
   [isMediaNotReadyError, Error.Category.MEDIA_NOT_READY],
-  [isIPRestrictedError, Error.Category.IP_RESTRICTED]
+  [isIPRestrictedError, Error.Category.IP_RESTRICTED],
+  [isScheduledRestrictedError, Error.Category.SCHEDULED_RESTRICTED],
+  [isSitedRestrictedError, Error.Category.SITE_RESTRICTED]
 ];
 
 function getErrorCategory(error: Error): number {


### PR DESCRIPTION
### Description of the Changes

Adding error messages to site restriction and scheduled restriction

Part of - https://github.com/kaltura/playkit-js-ui/pull/970, https://github.com/kaltura/playkit-js/pull/805, https://github.com/kaltura/playkit-js-providers/pull/245

Resolves [SUP-45003](https://kaltura.atlassian.net/browse/SUP-45003)

[SUP-45003]: https://kaltura.atlassian.net/browse/SUP-45003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ