### PR TITLE
fix(FEC-14289): Player v7 | Player doesn't recover well after network disconnection

### DIFF
--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -108,15 +108,15 @@ function validateProviderConfig(options: KalturaPlayerConfig): void {
 /**
  * Creates the player container dom element.
  * @private
- * @param {string} targetId - The div id which the player will append to.
  * @returns {string} - The player container id.
+ * @param options
  */
-function createKalturaPlayerContainer(targetId: string): string {
+function createKalturaPlayerContainer(options: PartialKPOptionsObject): string {
   const el = document.createElement('div');
-  el.id = Utils.Generator.uniqueId(5);
+  el.id = options?.ui['targetId'] || Utils.Generator.uniqueId(5);
   el.className = CONTAINER_CLASS_NAME;
   el.setAttribute('tabindex', '-1');
-  const parentNode = document.getElementById(targetId);
+  const parentNode = document.getElementById(options.targetId);
   if (parentNode && el) {
     parentNode.appendChild(el);
   }
@@ -337,7 +337,7 @@ function getServerUIConf(): any {
  * @returns {KalturaPlayerConfig} - default kaltura player options.
  */
 function getDefaultOptions(options: PartialKPOptionsObject): KalturaPlayerConfig {
-  const targetId = createKalturaPlayerContainer(options.targetId);
+  const targetId = createKalturaPlayerContainer(options);
   // TODO - fix all KalturaPlayerConfig and Partial relationships
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -113,7 +113,7 @@ function validateProviderConfig(options: KalturaPlayerConfig): void {
  */
 function createKalturaPlayerContainer(options: PartialKPOptionsObject): string {
   const el = document.createElement('div');
-  el.id = options?.ui['targetId'] || Utils.Generator.uniqueId(5);
+  el.id = options?.ui?.targetId || Utils.Generator.uniqueId(5);
   el.className = CONTAINER_CLASS_NAME;
   el.setAttribute('tabindex', '-1');
   const parentNode = document.getElementById(options.targetId);

--- a/tests/e2e/common/utils/setup-helpers.spec.js
+++ b/tests/e2e/common/utils/setup-helpers.spec.js
@@ -5,7 +5,9 @@ import * as SetupHelpers from '../../../../src/common/utils/setup-helpers';
 import { Env } from '@playkit-js/playkit-js';
 import { Images } from '../../mock-data/images';
 
-const targetId = 'player-placeholder_setup-helpers.spec';
+const options = {
+  targetId: 'player-placeholder_setup-helpers.spec'
+};
 
 describe('error handling', () => {
   it('should throw error because no config provided', (done) => {
@@ -100,15 +102,15 @@ describe('error handling', () => {
 
 describe('createKalturaPlayerContainer', () => {
   beforeEach(() => {
-    TestUtils.createElement('DIV', targetId);
+    TestUtils.createElement('DIV', options.targetId);
   });
 
   afterEach(() => {
-    TestUtils.removeElement(targetId);
+    TestUtils.removeElement(options.targetId);
   });
 
   it('should create kaltura player container', () => {
-    const containerId = SetupHelpers.createKalturaPlayerContainer(targetId);
+    const containerId = SetupHelpers.createKalturaPlayerContainer(options);
     const el = document.getElementById(containerId);
     el.should.exist;
     el.className.should.equal('kaltura-player-container');


### PR DESCRIPTION
### Description of the Changes
After player had network disconnection error and user clicked on 'Try Again', player should be **destroyed** and we should **setup** a new player before using **loadMedia**.

Related PR: https://github.com/kaltura/playkit-js-ui/pull/978

Resolves [FEC-14289](https://kaltura.atlassian.net/browse/FEC-14289)

[FEC-14289]: https://kaltura.atlassian.net/browse/FEC-14289