### PR TITLE
fix(SUP-46065): Player shows VR button based on "360" (or variations) tag

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -492,10 +492,9 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.isInPictureInPicture();
   }
 
-  public _updatePlayerVrPluginIsOn(vrTag: string): void {
-    this._provider._updatePlayerVrPluginIsOn(vrTag);
+  public setVrTag(vrTag: string): void {
+    this._provider.setVrTag(vrTag);
   }
-
   public isPictureInPictureSupported(): boolean {
     return this._localPlayer.isPictureInPictureSupported();
   }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -492,6 +492,10 @@ export class KalturaPlayer extends FakeEventTarget {
     return this._localPlayer.isInPictureInPicture();
   }
 
+  public _updatePlayerVrPluginIsOn(vrTag: string): void {
+    this._provider._updatePlayerVrPluginIsOn(vrTag);
+  }
+
   public isPictureInPictureSupported(): boolean {
     return this._localPlayer.isPictureInPictureSupported();
   }


### PR DESCRIPTION
issue:
360 tag is being concat and playing 360VR video when no needed.

fix:
support new feature: add to the configuration a tag in the vr plugin, and compare it to the metadata tags of the entry.
Tag is being transferred using the player, which transfer it to the provider.
https://github.com/kaltura/playkit-js-providers/pull/255
https://github.com/kaltura/playkit-js-vr/pull/110

solved:
[SUP-46065](https://kaltura.atlassian.net/browse/SUP-46065)

[SUP-46065]: https://kaltura.atlassian.net/browse/SUP-46065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ