### PR TITLE
fix(FEC-14248): shouldAddKs to be based on if the session contains ks

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -293,7 +293,7 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   public shouldAddKs(mediaConfig?: KPMediaConfig): boolean {
-    return !!(this.config?.provider?.loadThumbnailWithKs && (mediaConfig || this.config)?.session?.isAnonymous === false);
+    return !!(this.config?.provider?.loadThumbnailWithKs && (mediaConfig || this.config)?.session?.ks);
   }
 
   public getMediaInfo(): ProviderMediaInfoObject {

--- a/tests/e2e/kaltura-player.spec.ts
+++ b/tests/e2e/kaltura-player.spec.ts
@@ -251,14 +251,24 @@ describe('kaltura player api', () => {
               kalturaPlayer.shouldAddKs().should.equals(false);
             });
           });
-          describe('anonymous session', () => {
-            it('should return false for anonymous session when called without mediaConfig parameter', () => {
+          describe('session without ks', () => {
+            it('should return false for session without ks when called without mediaConfig parameter', () => {
               kalturaPlayer.setMedia(MediaMockData.MediaConfig['0_wifqaipd']);
               kalturaPlayer.shouldAddKs().should.equals(false);
             });
-            it('should return false for anonymous session when called with mediaConfig parameter', () => {
+            it('should return false for session without ks when called with mediaConfig parameter', () => {
               kalturaPlayer.setMedia(mediaWithUserSession);
               kalturaPlayer.shouldAddKs(MediaMockData.MediaConfig['0_wifqaipd']).should.equals(false);
+            });
+          });
+          describe('session with ks', () => {
+            it('should return true for session with ks when called without mediaConfig parameter', () => {
+              kalturaPlayer.setMedia(MediaMockData.MediaConfig['0_nwkp7jtx']);
+              kalturaPlayer.shouldAddKs().should.equals(true);
+            });
+            it('should return true for session with ks when called with mediaConfig parameter', () => {
+              kalturaPlayer.setMedia(mediaWithUserSession);
+              kalturaPlayer.shouldAddKs(MediaMockData.MediaConfig['0_nwkp7jtx']).should.equals(true);
             });
           });
           describe('user session', () => {

--- a/tests/e2e/mock-data/media.js
+++ b/tests/e2e/mock-data/media.js
@@ -4,7 +4,7 @@ const MediaConfig = {
       isAnonymous: true,
       partnerId: 1091,
       uiConfId: 15215933,
-      ks: 'OGViNDhkZGI4ZTM1ODAzYWVhYTk0OTZlMzcwMmZmZjUzMjZkNGFkMnwxMDkxOzEwOTE7MTU0NDY5MTMwODswOzE1NDQ2MDQ5MDguNTg4NDswO3ZpZXc6Kix3aWRnZXQ6MTs7'
+      ks: ''
     },
     sources: {
       hls: [


### PR DESCRIPTION
### Description of the Changes

shouldAddKs to be based on if the session contains ks instead of session.isAnonymous === false

Related PR: https://github.com/kaltura/playkit-js-providers/pull/259

[FEC-14248](https://kaltura.atlassian.net/browse/FEC-14248)


[FEC-14248]: https://kaltura.atlassian.net/browse/FEC-14248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ