### PR TITLE
change format to global variable instead umd in webpack.config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,10 +75,7 @@ module.exports = (env, { mode }) => {
     output: {
       filename: `kaltura-${playerFileType}-player.js`,
       path: path.resolve(__dirname, 'dist'),
-      library: {
-        name: 'KalturaPlayer',
-        type: 'umd'
-      },
+      library: 'KalturaPlayer',
       clean: mode === 'development'
     },
     devServer: {


### PR DESCRIPTION
### Description of the Changes

KalturaPlayer plugin depends on KalturaPlayer global variable so we need to remove 'AMD' build in webpack.

**Issue:**
https://github.com/kaltura/kaltura-player-js/issues/918
