### PR TITLE
feat(FEC-14415): Add option for initial HTTP GET api call to server

### DIFF
--- a/demo/player-ovp.html
+++ b/demo/player-ovp.html
@@ -21,9 +21,19 @@
           partnerId: 242,
           env: {
             cdnUrl: 'https://cfvod.nvq2.ovp.kaltura.com',
-            serviceUrl: 'https://api.nvq2.ovp.kaltura.com/api_v3'
+            serviceUrl: 'https://api.nvq2.ovp.kaltura.com/api_v3',
+            overrideServiceUrl : 'https://cfvod.nvq2.ovp.kaltura.com/api_v3',
+            initCallToServer:    "/service/system/action/getversion/format/1"
           }
         },
+        ui :{
+          hoverTimeout :777
+        },
+        playback: {
+          autoplay: true,
+          preload: "auto",
+        }
+
       };
 
       const player = KalturaPlayer.setup(config);

--- a/demo/player-ovp.html
+++ b/demo/player-ovp.html
@@ -23,7 +23,7 @@
             cdnUrl: 'https://cfvod.nvq2.ovp.kaltura.com',
             serviceUrl: 'https://api.nvq2.ovp.kaltura.com/api_v3',
             overrideServiceUrl : 'https://cfvod.nvq2.ovp.kaltura.com/api_v3',
-            initCallToServer:    "/service/system/action/getversion/format/1"
+            initCallToServer:    "/service/system/action/getversion"
           }
         },
         ui :{

--- a/demo/player-ovp.html
+++ b/demo/player-ovp.html
@@ -22,18 +22,8 @@
           env: {
             cdnUrl: 'https://cfvod.nvq2.ovp.kaltura.com',
             serviceUrl: 'https://api.nvq2.ovp.kaltura.com/api_v3',
-            overrideServiceUrl : 'https://cfvod.nvq2.ovp.kaltura.com/api_v3',
-            initCallToServer:    "/service/system/action/getversion"
           }
-        },
-        ui :{
-          hoverTimeout :777
-        },
-        playback: {
-          autoplay: true,
-          preload: "auto",
         }
-
       };
 
       const player = KalturaPlayer.setup(config);

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -814,6 +814,19 @@ function mergeProviderPluginsConfig(providerPluginsConfig: PluginsConfig, appPlu
   return [mergePluginConfig, respectiveAppPluginsConfig];
 }
 
+function maybeLoadInitialServerResponse(player: KalturaPlayer): void {
+  const { serviceUrl, initCallToServer } = player.provider.env;
+  if (initCallToServer) {
+    const url = serviceUrl + initCallToServer + '/format/1';
+    fetch(url).then((response) => {
+      response.json().then((data) => {
+        getLogger().log(`Initial server response: ${data}`);
+      });
+    });
+  }
+  return;
+}
+
 export {
   printSetupMessages,
   supportLegacyOptions,
@@ -838,5 +851,6 @@ export {
   mergeProviderPluginsConfig,
   getServerUIConf,
   initializeStorageManagers,
+  maybeLoadInitialServerResponse,
   KALTURA_PLAYER_START_TIME_QS
 };

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -15,7 +15,8 @@ import {
   setStorageTextStyle,
   supportLegacyOptions,
   validateConfig,
-  validateProviderConfig, maybeLoadInitialServerResponse
+  validateProviderConfig,
+  maybeLoadInitialServerResponse
 } from './common/utils/setup-helpers';
 import { PartialKPOptionsObject } from './types';
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -32,8 +32,6 @@ function setup(options: PartialKPOptionsObject): KalturaPlayer {
   const defaultOptions = getDefaultOptions(options);
   validateProviderConfig(defaultOptions);
   setLogOptions(defaultOptions);
-  //add function that gets server version based on service admin action version
-
   maybeApplyStartTimeQueryParam(defaultOptions);
   maybeApplyClipQueryParams(defaultOptions);
   printSetupMessages();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -15,7 +15,7 @@ import {
   setStorageTextStyle,
   supportLegacyOptions,
   validateConfig,
-  validateProviderConfig
+  validateProviderConfig, maybeLoadInitialServerResponse
 } from './common/utils/setup-helpers';
 import { PartialKPOptionsObject } from './types';
 
@@ -32,12 +32,15 @@ function setup(options: PartialKPOptionsObject): KalturaPlayer {
   const defaultOptions = getDefaultOptions(options);
   validateProviderConfig(defaultOptions);
   setLogOptions(defaultOptions);
+  //add function that gets server version based on service admin action version
+
   maybeApplyStartTimeQueryParam(defaultOptions);
   maybeApplyClipQueryParams(defaultOptions);
   printSetupMessages();
   initializeStorageManagers();
   setStorageConfig(defaultOptions);
   const player = getPlayerProxy(defaultOptions);
+  maybeLoadInitialServerResponse(player);
   setStorageTextStyle(player);
   applyStorageSupport(player);
   applyCastSupport(defaultOptions, player);


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**
https://kaltura.atlassian.net/browse/FEC-14415
Players calls are being blocked by proxy, since first call is a complex POST call,
To overcome it, we need the first call to be an HTTP GET call.

**Fix:**
User can add config - 
  provider: {
          env: {
            initCallToServer:    "/service/system/action/getversion"
          }
      }
Once this is added, the first api call to the server will be to <serverURL>**/service/system/action/getversion/f**ormat/1
#### Resolves FEC-14415
