### PR TITLE
fix(CR-200): fix clipped thumbnail sprite

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@playkit-js/playkit-js": "0.84.25-canary.0-7342358",
     "@playkit-js/playkit-js-dash": "1.38.0",
     "@playkit-js/playkit-js-hls": "1.32.17-canary.0-66ce8a1",
-    "@playkit-js/playkit-js-providers": "2.42.0",
+    "@playkit-js/playkit-js-providers": "2.42.1-canary.0-476be37",
     "@playkit-js/playkit-js-ui": "0.81.2-canary.0-11e49fd",
     "@playkit-js/webpack-common": "^1.0.3",
     "hls.js": "^1.5.8",

--- a/src/common/thumbnail-manager.ts
+++ b/src/common/thumbnail-manager.ts
@@ -41,9 +41,7 @@ class ThumbnailManager {
 
   private _buildClipData(mediaConfig: KPMediaConfig): ClipData {
     return {
-      // @ts-expect-error - seekFrom does not exist on KPMediaConfig
       seekFrom: mediaConfig.sources.seekFrom || Utils.Object.getPropertyPath(this._player.config.sources, 'seekFrom'),
-      // @ts-expect-error - clipTo does not exist on KPMediaConfig
       clipTo: mediaConfig.sources.clipTo || Utils.Object.getPropertyPath(this._player.config.sources, 'clipTo')
     };
   }

--- a/src/common/thumbnail-manager.ts
+++ b/src/common/thumbnail-manager.ts
@@ -10,6 +10,11 @@ const DefaultThumbnailConfig: any = {
   thumbsSlices: 100
 };
 
+type ClipData = {
+  seekFrom: number | undefined;
+  clipTo: number | undefined;
+};
+
 const THUMBNAIL_REGEX = /.*\/p\/\d+\/(?:[a-zA-Z]+\/\d+\/)*thumbnail\/entry_id\/\w+\/.*\d+/;
 const THUMBNAIL_SERVICE_TEMPLATE: string = '{{thumbnailUrl}}/width/{{thumbsWidth}}/vid_slices/{{thumbsSlices}}';
 
@@ -18,9 +23,11 @@ class ThumbnailManager {
   private _thumbnailConfig: KPThumbnailConfig;
   private _eventManager: EventManager;
   private _thumbsHeight!: number;
+  private _clipData: ClipData;
 
   constructor(player: KalturaPlayer, uiConfig: UiConfig, mediaConfig: KPMediaConfig) {
     this._player = player;
+    this._clipData = this._buildClipData(mediaConfig);
     this._thumbnailConfig = this._buildKalturaThumbnailConfig(uiConfig, mediaConfig);
     this._eventManager = new EventManager();
     if (this._isUsingKalturaThumbnail()) {
@@ -30,6 +37,15 @@ class ThumbnailManager {
       });
       img.src = this._thumbnailConfig?.thumbsSprite || '';
     }
+  }
+
+  private _buildClipData(mediaConfig: KPMediaConfig): ClipData {
+    return {
+      // @ts-expect-error - seekFrom does not exist on KPMediaConfig
+      seekFrom: mediaConfig.sources.seekFrom || Utils.Object.getPropertyPath(this._player.config.sources, 'seekFrom'),
+      // @ts-expect-error - clipTo does not exist on KPMediaConfig
+      clipTo: mediaConfig.sources.clipTo || Utils.Object.getPropertyPath(this._player.config.sources, 'clipTo')
+    };
   }
 
   public destroy(): void {
@@ -83,14 +99,13 @@ class ThumbnailManager {
   };
 
   private _maybeCutThumbnail = (baseUrl: string): string => {
-    const seekFromConfig = Utils.Object.getPropertyPath(this._player.config.sources, 'seekFrom');
-    const clipToConfig = Utils.Object.getPropertyPath(this._player.config.sources, 'clipTo');
+    const { seekFrom, clipTo } = this._clipData;
     let url = baseUrl;
-    if (typeof seekFromConfig === 'number') {
-      url += `/start_sec/${seekFromConfig}`;
+    if (typeof seekFrom === 'number') {
+      url += `/start_sec/${seekFrom}`;
     }
-    if (typeof clipToConfig === 'number') {
-      url += `/end_sec/${clipToConfig}`;
+    if (typeof clipTo === 'number') {
+      url += `/end_sec/${clipTo}`;
     }
     return url;
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,10 +1184,10 @@
   resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.32.17-canary.0-66ce8a1.tgz#ae10935e548a519c79cdf11c56b1246276a2fac8"
   integrity sha512-5xwz9DXcOzG2mwjkSrUsTvLZnclWheE2lqPJbng/Bi+qnJjtVQZvbxZrfhrGfeA7yVRQKWNjokwSZag8ziIkaQ==
 
-"@playkit-js/playkit-js-providers@2.42.0":
-  version "2.42.0"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.42.0.tgz#6c730bb1418dab4d0ce086a6f1bab7ca4d997f14"
-  integrity sha512-KmEtGd0iMoF/pYCUIETNHTqZNTPubh2mLZngh7Ype0O94SmBcVn9nrJCeKCbsoYWC0qtkJCRB1BMnA1bMSIsvQ==
+"@playkit-js/playkit-js-providers@2.42.1-canary.0-476be37":
+  version "2.42.1-canary.0-476be37"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-providers/-/playkit-js-providers-2.42.1-canary.0-476be37.tgz#f2155d6f8a3bbbace97566ea2280db0241a13a4d"
+  integrity sha512-TwhMXZ5SMj3l2ZQrow7cnetT/v0C9omzzLGaGrTtWILO1oLWo1E+++4MlkxIQAiPKl7srUP0IoyOq7XDDfiHmA==
 
 "@playkit-js/playkit-js-ui@0.81.2-canary.0-11e49fd":
   version "0.81.2-canary.0-11e49fd"


### PR DESCRIPTION
### Description of the Changes

**Issue:**
`seekFrom` and `clipTo` are not always configured on player level, they might be configured on media level using `loadMedia` api. see following example:
```
player.loadMedia({entryId: '1_xxx'}, {seekFrom: 10, clipTo: 72});
```
currently, in case it comes from the `mediaConfig`, the values do not exist on player level so the thumbnail sprite is wrong and does not include the clipping points.

**Fix:**
save `clipData` from `mediaConfig` or player configuration as fallback.

#### Resolves [CR-200](https://kaltura.atlassian.net/browse/CR-200)


[CR-200]: https://kaltura.atlassian.net/browse/CR-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ