### PR TITLE
feat(FEC-14445): Add Debug Info Option to the Player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 dist
 lib/
-demo/
 node_modules
 *.log
 types/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 lib/
+demo/
 node_modules
 *.log
 types/

--- a/demo/player-ovp.html
+++ b/demo/player-ovp.html
@@ -14,14 +14,15 @@
     <script type="text/javascript">
       const config = {
         log: {
-          level: 'DEBUG'
+          level: 'DEBUG',
+          useDebugInfo: true
         },
         targetId: 'player-placeholder',
         provider: {
           partnerId: 242,
           env: {
             cdnUrl: 'https://cfvod.nvq2.ovp.kaltura.com',
-            serviceUrl: 'https://api.nvq2.ovp.kaltura.com/api_v3',
+            serviceUrl: 'https://api.nvq2.ovp.kaltura.com/api_v3'
           }
         }
       };

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -275,7 +275,8 @@ function maybeApplyClipQueryParams(options: KalturaPlayerConfig): void {
 }
 
 const logHandlers: Array<(messages: any[], context: object) => void> = [];
-let logBuffer = '';
+const LOG_BUFFER_SIZE = 1000;
+const logBuffer: string[] = [];
 
 const logHandler = (messages: any[], ctx: { name: string }) => {
   logHandlers.forEach((handler: ILogHandler): void => {
@@ -307,7 +308,11 @@ function setLogOptions(options: KalturaPlayerConfig): void {
       // eslint-disable-next-line no-console
       console.log(message);
 
-      logBuffer += `${new Date().toLocaleString()} ${message} \n`;
+      if (logBuffer.length === LOG_BUFFER_SIZE) {
+        logBuffer.shift();
+      }
+
+      logBuffer.push(`${new Date().toLocaleString()} ${message} \n`);
     });
   }
 
@@ -868,7 +873,7 @@ function maybeLoadInitialServerResponse(player: KalturaPlayer): void {
 }
 
 function getLogBuffer(): string {
-  return logBuffer;
+  return logBuffer.join('');
 }
 
 export {

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -275,7 +275,7 @@ function maybeApplyClipQueryParams(options: KalturaPlayerConfig): void {
 }
 
 const logHandlers: Array<(messages: any[], context: object) => void> = [];
-let logBuffer = ''; //new Map<string, string>();
+let logBuffer = '';
 
 const logHandler = (messages: any[], ctx: { name: string }) => {
   logHandlers.forEach((handler: ILogHandler): void => {
@@ -301,7 +301,6 @@ function setLogOptions(options: KalturaPlayerConfig): void {
   }
 
   if (options.log && options.log.useDebugInfo) {
-    // log handler - console and buffer
     logHandlers.push((messages, ctx) => {
       const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
       // when we use a handler, we have to explicitly print the message to console
@@ -311,7 +310,7 @@ function setLogOptions(options: KalturaPlayerConfig): void {
     });
   }
 
-  // log handler - custom
+  // add custom log handlers
   if (options.log && typeof options.log.handler === 'function') {
     logHandlers.push(options.log.handler);
   }

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -300,10 +300,11 @@ function setLogOptions(options: KalturaPlayerConfig): void {
     Utils.Object.createPropertyPath(options, 'log', {});
   }
 
-  if (options.log && options.log.useDebugInfo) {
+  if (options.log && (options.log as any).useDebugInfo) {
     logHandlers.push((messages, ctx) => {
       const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
       // when we use a handler, we have to explicitly print the message to console
+      // eslint-disable-next-line no-console
       console.log(message);
 
       logBuffer += `${new Date().toLocaleString()} ${message} \n`;

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -57,10 +57,11 @@ import {
   hasYoutubeSource,
   maybeSetStreamPriority,
   mergeProviderPluginsConfig,
-  supportLegacyOptions
+  supportLegacyOptions,
+  getLogBuffer
 } from './common/utils/setup-helpers';
 import { getDefaultRedirectOptions } from 'player-defaults';
-import { addKalturaParams, getOriginalRequestReferrer } from './common/utils/kaltura-params';
+import { addKalturaParams, getOriginalRequestReferrer, getReferrer } from './common/utils/kaltura-params';
 import { addKalturaPoster } from 'poster';
 import { RemoteSession } from './common/cast/remote-session';
 import getMediaCapabilities from './common/utils/media-capabilities';
@@ -1203,6 +1204,27 @@ export class KalturaPlayer extends FakeEventTarget {
 
   public get sessionIdCache(): SessionIdCache | null {
     return this._sessionIdCache;
+  }
+
+  private _debugInfo = {};
+
+  public get debugInfo(): any {
+    const log = getLogBuffer();
+    const referrer = getReferrer();
+
+    return {
+      embedUrl: window.location.href,
+      userAgent: navigator.userAgent,
+      referrer,
+      targetId: this.config.targetId,
+      playerVersion: (window as any).KalturaPlayer?.VERSION,
+      partnerId: this.config.provider?.partnerId,
+      entryId: this.sources.id,
+      playlistId: this.playlist?.id,
+      manifestUrl: this.selectedSource?.url,
+      plugins: [...Object.keys(this.plugins)],
+      log
+    };
   }
 
   private handleSourcesTimeRangeUpdate(seekFrom: number | undefined, clipTo: number | undefined): void {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1207,6 +1207,8 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   public get debugInfo(): any {
+    if (!this.config.log?.useDebugInfo) return null;
+
     const log = getLogBuffer();
     const referrer = getReferrer();
 

--- a/src/types/log-level.ts
+++ b/src/types/log-level.ts
@@ -2,5 +2,5 @@ export interface LogConfig {
   playerVersion?: boolean;
   level: string;
   handler?: (messages: any[], context: Object) => void;
-  useDebugInfo: boolean;
+  useDebugInfo?: boolean;
 }

--- a/src/types/log-level.ts
+++ b/src/types/log-level.ts
@@ -2,4 +2,5 @@ export interface LogConfig {
   playerVersion?: boolean;
   level: string;
   handler?: (messages: any[], context: Object) => void;
+  useDebugInfo: boolean;
 }


### PR DESCRIPTION
### Description of the Changes

Add a debugInfo field to the player, containing player information including logs
Note - the log handler does not distinguish between different players on one page, so enabling useDebugInfo in ONE player will cause player.debugInfo to contain logs from ALL players

Related PR: https://github.com/kaltura/playkit-js-ui/pull/1012

Resolves FEC-14445
