### PR TITLE
fix: (SUP-48028): Player V7 does not display access control message

### DIFF
--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -9,7 +9,7 @@ const isSessionRestricted = (error: Error): boolean => error.data?.messages && e
 const isIPRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'IP_RESTRICTED';
 const isSitedRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SITE_RESTRICTED';
 const isScheduledRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SCHEDULED_RESTRICTED';
-const isAccessControlRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 14
+const isAccessControlRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 14;
 
 const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSessionRestricted(error);
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -15,7 +15,7 @@ const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);
 const isMediaNotReadyError = (error: Error): boolean => isBackEndError(error) && isMediaNotReady(error);
 const isIPRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isIPRestricted(error);
-const isAccessControlRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isAccessControlRestricted(error)
+const isAccessControlRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isAccessControlRestricted(error);
 const isSitedRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSitedRestricted(error);
 const isScheduledRestrictedError = (error: Error): boolean =>
   isBackEndError(error) && isScheduledRestrictedCode(error) && isScheduledRestricted(error);

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -9,11 +9,13 @@ const isSessionRestricted = (error: Error): boolean => error.data?.messages && e
 const isIPRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'IP_RESTRICTED';
 const isSitedRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SITE_RESTRICTED';
 const isScheduledRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SCHEDULED_RESTRICTED';
+const isAccessControlRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 14
 
 const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSessionRestricted(error);
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);
 const isMediaNotReadyError = (error: Error): boolean => isBackEndError(error) && isMediaNotReady(error);
 const isIPRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isIPRestricted(error);
+const isAccessControlRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isAccessControlRestricted(error)
 const isSitedRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSitedRestricted(error);
 const isScheduledRestrictedError = (error: Error): boolean =>
   isBackEndError(error) && isScheduledRestrictedCode(error) && isScheduledRestricted(error);
@@ -24,7 +26,8 @@ const conditionsToErrors: any[] = [
   [isMediaNotReadyError, Error.Category.MEDIA_NOT_READY],
   [isIPRestrictedError, Error.Category.IP_RESTRICTED],
   [isScheduledRestrictedError, Error.Category.SCHEDULED_RESTRICTED],
-  [isSitedRestrictedError, Error.Category.SITE_RESTRICTED]
+  [isSitedRestrictedError, Error.Category.SITE_RESTRICTED],
+  [isAccessControlRestrictedError, Error.Category.ACCESS_CONTROL_BLOCKED]
 ];
 
 function getErrorCategory(error: Error): number {

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -9,7 +9,7 @@ const isSessionRestricted = (error: Error): boolean => error.data?.messages && e
 const isIPRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'IP_RESTRICTED';
 const isSitedRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SITE_RESTRICTED';
 const isScheduledRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SCHEDULED_RESTRICTED';
-const isAccessControlRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 14;
+const isAccessControlRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'ACCESS_CONTROL_BLOCKED';
 
 const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSessionRestricted(error);
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);


### PR DESCRIPTION
Issue:
Blocked Access Control error is not supported.

Fix:
Add support to new Error type

solved [SUP-48028](https://kaltura.atlassian.net/browse/SUP-48028)

related PRS:
https://github.com/kaltura/playkit-js/pull/816
https://github.com/kaltura/playkit-js-ui/pull/1014

[SUP-48028]: https://kaltura.atlassian.net/browse/SUP-48028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ