### PR TITLE
fix(SUP-48030): player V7 display issue on playlist with blocked and non-blocked content

### DIFF
--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -127,7 +127,7 @@ class PlaylistManager {
    */
   public playNext(playlistGotError: Boolean = false): void {
     if (playlistGotError) {
-      this._player.clearReset()
+      this._player.clearReset();
     }
     PlaylistManager._logger.debug('playNext');
     const next = this._playlist.getNext(true);

--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -127,7 +127,7 @@ class PlaylistManager {
    */
   public playNext(playlistGotError: Boolean = false): void {
     if(playlistGotError) {
-      this._player.setLocalPlayerReset(false);
+      this._player.clearReset()
     }
     PlaylistManager._logger.debug('playNext');
     const next = this._playlist.getNext(true);

--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -125,7 +125,7 @@ class PlaylistManager {
    * @instance
    * @memberof PlaylistManager
    */
-  public playNext(playlistGotError: Boolean = false): void {
+  public playNext(playlistGotError: boolean = false): void {
     if (playlistGotError) {
       this._player.clearReset();
     }

--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -126,7 +126,7 @@ class PlaylistManager {
    * @memberof PlaylistManager
    */
   public playNext(playlistGotError: Boolean = false): void {
-    if(playlistGotError) {
+    if (playlistGotError) {
       this._player.clearReset()
     }
     PlaylistManager._logger.debug('playNext');

--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -125,7 +125,10 @@ class PlaylistManager {
    * @instance
    * @memberof PlaylistManager
    */
-  public playNext(): void {
+  public playNext(playlistGotError: Boolean = false): void {
+    if(playlistGotError) {
+      this._player.setLocalPlayerReset(false);
+    }
     PlaylistManager._logger.debug('playNext');
     const next = this._playlist.getNext(true);
     if (next) {

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -257,9 +257,10 @@ export class KalturaPlayer extends FakeEventTarget {
     this._playlistManager.load(playlistData, playlistConfig, entryList);
   }
 
-  public setLocalPlayerReset(reset: boolean) {
-    this._localPlayer._reset = reset;
+  public clearReset() {
+    this._localPlayer._reset = false;
   }
+  
   public configure(config: Partial<KalturaPlayerConfig> = {}): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -257,7 +257,7 @@ export class KalturaPlayer extends FakeEventTarget {
     this._playlistManager.load(playlistData, playlistConfig, entryList);
   }
 
-  public clearReset() {
+  public clearReset(): void {
     this._localPlayer.clearReset();
   }
 

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -258,9 +258,9 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   public clearReset() {
-    this._localPlayer._reset = false;
+    this._localPlayer.clearReset();
   }
-  
+
   public configure(config: Partial<KalturaPlayerConfig> = {}): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -257,6 +257,9 @@ export class KalturaPlayer extends FakeEventTarget {
     this._playlistManager.load(playlistData, playlistConfig, entryList);
   }
 
+  public setLocalPlayerReset(reset: boolean) {
+    this._localPlayer._reset = reset;
+  }
   public configure(config: Partial<KalturaPlayerConfig> = {}): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore


### PR DESCRIPTION
**Issue:**
When an entry that is part of a playlist got an error, it keeps the previous entry instead of the current entry to play.

**Fix:**
Add a case inside playNext, when a playlist that is part of the entry gets error.

solved [SUP-48030](https://kaltura.atlassian.net/browse/SUP-48030)

part of this PR: https://github.com/kaltura/playkit-js-playlist/pull/77
https://github.com/kaltura/playkit-js/pull/817

[SUP-48030]: https://kaltura.atlassian.net/browse/SUP-48030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ