### PR TITLE
fix (SUP-48028): Player V7 does not display access control message

### DIFF
--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -9,7 +9,6 @@ const isSessionRestricted = (error: Error): boolean => error.data?.messages && e
 const isIPRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'IP_RESTRICTED';
 const isSitedRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SITE_RESTRICTED';
 const isScheduledRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SCHEDULED_RESTRICTED';
-const isAccessControlRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'ACCESS_CONTROL_BLOCKED';
 
 const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSessionRestricted(error);
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);
@@ -17,8 +16,17 @@ const isMediaNotReadyError = (error: Error): boolean => isBackEndError(error) &&
 const isIPRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isIPRestricted(error);
 const isAccessControlRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isAccessControlRestricted(error);
 const isSitedRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSitedRestricted(error);
-const isScheduledRestrictedError = (error: Error): boolean =>
-  isBackEndError(error) && isScheduledRestrictedCode(error) && isScheduledRestricted(error);
+const isAccessControlRestricted = (error: Error): boolean => {
+  return (
+    isBackEndError(error) &&
+    isBlockAction(error) &&
+    !isGeolocationRestricted(error) &&
+    !isSessionRestricted(error) &&
+    !isIPRestricted(error) &&
+    !isSitedRestricted(error) &&
+    !isScheduledRestricted(error)
+  );
+};
 
 const conditionsToErrors: any[] = [
   [isSessionRestrictedError, Error.Category.MEDIA_UNAVAILABLE],

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -14,18 +14,18 @@ const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);
 const isMediaNotReadyError = (error: Error): boolean => isBackEndError(error) && isMediaNotReady(error);
 const isIPRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isIPRestricted(error);
-const isAccessControlRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isAccessControlRestricted(error);
 const isSitedRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSitedRestricted(error);
-const isAccessControlRestricted = (error: Error): boolean => {
-  return (
-    isBackEndError(error) &&
-    isBlockAction(error) &&
-    !isGeolocationRestricted(error) &&
-    !isSessionRestricted(error) &&
-    !isIPRestricted(error) &&
-    !isSitedRestricted(error) &&
-    !isScheduledRestricted(error)
-  );
+const isScheduledRestrictedError = (error: Error): boolean =>
+  isBackEndError(error) && isScheduledRestrictedCode(error) && isScheduledRestricted(error);
+const isAccessControlRestrictedError = (error: Error): boolean => { return (
+  isBackEndError(error) &&
+  isBlockAction(error) &&
+  !isGeolocationRestricted(error) &&
+  !isSessionRestricted(error) &&
+  !isIPRestricted(error) &&
+  !isSitedRestricted(error) &&
+  !isScheduledRestricted(error)
+);
 };
 
 const conditionsToErrors: any[] = [

--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -17,15 +17,16 @@ const isIPRestrictedError = (error: Error): boolean => isBackEndError(error) && 
 const isSitedRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSitedRestricted(error);
 const isScheduledRestrictedError = (error: Error): boolean =>
   isBackEndError(error) && isScheduledRestrictedCode(error) && isScheduledRestricted(error);
-const isAccessControlRestrictedError = (error: Error): boolean => { return (
-  isBackEndError(error) &&
-  isBlockAction(error) &&
-  !isGeolocationRestricted(error) &&
-  !isSessionRestricted(error) &&
-  !isIPRestricted(error) &&
-  !isSitedRestricted(error) &&
-  !isScheduledRestricted(error)
-);
+const isAccessControlRestrictedError = (error: Error): boolean => {
+  return (
+    isBackEndError(error) &&
+    isBlockAction(error) &&
+    !isGeolocationRestricted(error) &&
+    !isSessionRestricted(error) &&
+    !isIPRestricted(error) &&
+    !isSitedRestricted(error) &&
+    !isScheduledRestricted(error)
+  );
 };
 
 const conditionsToErrors: any[] = [


### PR DESCRIPTION
Issue: custom error codes returned by the PS backend are not currently matched by any known fronted error handling logic.

Fix: If we got an error from backend which is blocking content but its code does not match to the known codes the player already handles, than we will display a generic error of access control blocked.

solved [SUP-48028](https://kaltura.atlassian.net/browse/SUP-48028)

[SUP-48028]: https://kaltura.atlassian.net/browse/SUP-48028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ