### PR TITLE
fix(FEC-14478): When log.useDebugInfo is false, the player doesnt print to log 

### DIFF
--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -295,7 +295,7 @@ function setLogOptions(options: KalturaPlayerConfig): void {
     const messagesStr = [...messages]
       .map((msg) => {
         try {
-          // stringify objects, but protect against circular references errors
+          // stringify objects, but protect against circular reference errors
           return typeof msg === 'string' ? msg : JSON.stringify(msg);
         } catch (e) {
           return msg;

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -291,6 +291,21 @@ const logHandler = (messages: any[], ctx: { name: string }) => {
  * @returns {void}
  */
 function setLogOptions(options: KalturaPlayerConfig): void {
+  function getFormattedMessage(messages: any[], ctx: any): string {
+    const messagesStr = [...messages]
+      .map((msg) => {
+        try {
+          // stringify objects, but protect against circular references errors
+          return typeof msg === 'string' ? msg : JSON.stringify(msg);
+        } catch (e) {
+          return msg;
+        }
+      })
+      .join(' ');
+
+    return `[${(ctx as { name: string }).name}] ${messagesStr}`;
+  }
+
   if (!Utils.Object.getPropertyPath(options, 'ui.log')) {
     Utils.Object.createPropertyPath(options, 'ui.log', {});
   }
@@ -302,15 +317,14 @@ function setLogOptions(options: KalturaPlayerConfig): void {
   }
 
   logHandlers.push((messages, ctx) => {
-    const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
     // when we use a handler, we have to explicitly print the message to console
     // eslint-disable-next-line no-console
-    console.log(message);
+    console.log(getFormattedMessage(messages, ctx));
   });
 
   if (options.log && (options.log as any).useDebugInfo) {
     logHandlers.push((messages, ctx) => {
-      const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
+      const message = getFormattedMessage(messages, ctx);
 
       if (logBuffer.length === LOG_BUFFER_SIZE) {
         logBuffer.shift();

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -301,12 +301,16 @@ function setLogOptions(options: KalturaPlayerConfig): void {
     Utils.Object.createPropertyPath(options, 'log', {});
   }
 
+  logHandlers.push((messages, ctx) => {
+    const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
+    // when we use a handler, we have to explicitly print the message to console
+    // eslint-disable-next-line no-console
+    console.log(message);
+  });
+
   if (options.log && (options.log as any).useDebugInfo) {
     logHandlers.push((messages, ctx) => {
       const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
-      // when we use a handler, we have to explicitly print the message to console
-      // eslint-disable-next-line no-console
-      console.log(message);
 
       if (logBuffer.length === LOG_BUFFER_SIZE) {
         logBuffer.shift();
@@ -314,15 +318,7 @@ function setLogOptions(options: KalturaPlayerConfig): void {
 
       logBuffer.push(`${new Date().toLocaleString()} ${message} \n`);
     });
-  } else {
-    logHandlers.push((messages, ctx) => {
-      const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
-      // when we use a handler, we have to explicitly print the message to console
-      // eslint-disable-next-line no-console
-      console.log(message);
-    });
   }
-
   // add custom log handlers
   if (options.log && typeof options.log.handler === 'function') {
     logHandlers.push(options.log.handler);

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -314,6 +314,13 @@ function setLogOptions(options: KalturaPlayerConfig): void {
 
       logBuffer.push(`${new Date().toLocaleString()} ${message} \n`);
     });
+  } else {
+    logHandlers.push((messages, ctx) => {
+      const message = `[${(ctx as { name: string }).name}] ${[...messages].join(' ')}`;
+      // when we use a handler, we have to explicitly print the message to console
+      // eslint-disable-next-line no-console
+      console.log(message);
+    });
   }
 
   // add custom log handlers

--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -295,7 +295,7 @@ function setLogOptions(options: KalturaPlayerConfig): void {
     const messagesStr = [...messages]
       .map((msg) => {
         try {
-          // stringify objects, but protect against circular reference errors
+          // stringify objects, but protect against errors (e.g. circular references)
           return typeof msg === 'string' ? msg : JSON.stringify(msg);
         } catch (e) {
           return msg;


### PR DESCRIPTION
### Description of the Changes

Since we no longer use the default log handler (because we use a custom handler so we can append to the log buffer), we now have to explicitly call console.log with log messages - even when useDebugInfo is false

Also added use of JSON.stringify in case logger receives an object param

Resolves FEC-14478
