### PR TITLE
fix(FEC-14477): When turning on captions using CC button, after refresh captions are off again

### DIFF
--- a/src/common/storage/local-storage-manager.ts
+++ b/src/common/storage/local-storage-manager.ts
@@ -53,27 +53,18 @@ export default class LocalStorageManager extends BaseStorageManager {
       this.setItem(this.StorageKeys.AUDIO_LANG, audioTrack.language);
     });
 
-    eventManager.listen(player, player.Event.UI.USER_SELECTED_CAPTION_TRACK, (event) => {
-      const textTrack = event.payload.captionTrack;
-      if (textTrack.language !== 'off') {
-        this.setItem(this.StorageKeys.TEXT_LANG, textTrack.language);
-        this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, true);
-      } else {
-        this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, false);
-      }
-    });
-
-    const onToggleCaptions = (selectedTextTrack): any => {
-      if (selectedTextTrack.language !== 'off') {
-        this.setItem(this.StorageKeys.TEXT_LANG, selectedTextTrack.language);
+    const onToggleCaptions = (language): any => {
+      if (language && language !== 'off') {
+        this.setItem(this.StorageKeys.TEXT_LANG, language);
         this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, true);
       } else {
         this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, false);
       }
     };
 
-    eventManager.listen(player, player.Event.UI.USER_SHOWED_CAPTIONS, () => onToggleCaptions(player.getActiveTracks()[player.Track.TEXT]));
-    eventManager.listen(player, player.Event.UI.USER_HID_CAPTIONS, () => onToggleCaptions({ language: 'off' }));
+    eventManager.listen(player, player.Event.UI.USER_SELECTED_CAPTION_TRACK, ({ payload }) => onToggleCaptions(payload.captionTrack?.language));
+    eventManager.listen(player, player.Event.UI.USER_SHOWED_CAPTIONS, ({ payload }) => onToggleCaptions(payload.language));
+    eventManager.listen(player, player.Event.UI.USER_HID_CAPTIONS, () => onToggleCaptions('off'));
 
     eventManager.listen(player, player.Event.UI.USER_SELECTED_CAPTIONS_STYLE, (event) => {
       try {

--- a/src/common/storage/local-storage-manager.ts
+++ b/src/common/storage/local-storage-manager.ts
@@ -63,20 +63,17 @@ export default class LocalStorageManager extends BaseStorageManager {
       }
     });
 
-    const onToggleCaptions = (): any => {
-      eventManager.listenOnce(player, player.Event.Core.TEXT_TRACK_CHANGED, (event) => {
-        const { selectedTextTrack } = event.payload;
-        if (selectedTextTrack.language !== 'off') {
-          this.setItem(this.StorageKeys.TEXT_LANG, selectedTextTrack.language);
-          this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, true);
-        } else {
-          this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, false);
-        }
-      });
+    const onToggleCaptions = (selectedTextTrack): any => {
+      if (selectedTextTrack.language !== 'off') {
+        this.setItem(this.StorageKeys.TEXT_LANG, selectedTextTrack.language);
+        this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, true);
+      } else {
+        this.setItem(this.StorageKeys.CAPTIONS_DISPLAY, false);
+      }
     };
 
-    eventManager.listen(player, player.Event.UI.USER_SHOWED_CAPTIONS, onToggleCaptions);
-    eventManager.listen(player, player.Event.UI.USER_HID_CAPTIONS, onToggleCaptions);
+    eventManager.listen(player, player.Event.UI.USER_SHOWED_CAPTIONS, () => onToggleCaptions(player.getActiveTracks()[player.Track.TEXT]));
+    eventManager.listen(player, player.Event.UI.USER_HID_CAPTIONS, () => onToggleCaptions({ language: 'off' }));
 
     eventManager.listen(player, player.Event.UI.USER_SELECTED_CAPTIONS_STYLE, (event) => {
       try {


### PR DESCRIPTION
### Problem:
When captions are off and the user clicks on the cc button, user caption selection is not saved in localStorage

### Explanation:
Before commit https://github.com/kaltura/playkit-js-ui/commit/0aa3d69c287660916a0815b5233730ac1f4757ed#diff-22612db7ea774e3c6e8ffa651e42a8c07285f8e0241a11b93f8d1f50211161ccR116

When captions were turned off and the user would click on the CC button:
1. USER_SHOWED_CAPTIONS event would be fired.
2. The USER_SHOWED_CAPTIONS event handler would add a listener to TEXT_TRACK_CHANGED.
3. showTextTrack would be called and would update the text track selection.
4. TEXT_TRACK_CHANGED would be fired.
5. The TEXT_TRACK_CHANGED event handler would get the new text track selection and save it in localStorage.

However, because we would fire the USER_SHOWED_CAPTIONS event first and then actually make the track change, attempting to add the active text track to the USER_SHOWED_CAPTIONS event payload would use the previous active text track ("off"), not the new (upcoming) one.

After the above commit, we now first make the text track change, then fire the USER_SHOWED_CAPTIONS event.
This way, kava plugin receives the correct language selection payload.
However, the TEXT_TRACK_CHANGED event handler is never fired, because the text track change has already been made, 
so the text track change is never saved to localStorage and captionsDisplay stays false.

### Solution:
- In case of USER_SHOWED_CAPTIONS event, the text track selection is already updated, so we can take the data from the player or from the event payload.
- In the case of USER_HID_CAPTIONS event, we still fire the event first and then make the change, so we can't take the updated text track data from the player yet. But because we know it's a USER_HID_CAPTIONS event, we know that the new (upcoming) selected track will be "off", so we just set CAPTIONS_DISPLAY to false directly.