### PR TITLE
feat(FEC-14544): add support to KalturaPlayers

### DIFF
--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -25,6 +25,7 @@ import { BaseStorageManager } from '../storage/base-storage-manager';
 import { BasePlugin } from '../plugins';
 import { KalturaPlayerConfig, LegacyPartialKPOptionsObject, PartialKPOptionsObject, PluginsConfig, PlaybackConfig } from '../../types';
 import { SessionIdGenerator } from './session-id-generator';
+import { UiConfIdSingleton } from './ui-conf-id-singleton';
 
 const setupMessages: Array<any> = [];
 const CONTAINER_CLASS_NAME: string = 'kaltura-player-container';
@@ -392,7 +393,24 @@ function getUrlParameter(name: string): string | null {
  * @returns {Object} - The server UIConf
  */
 function getServerUIConf(): any {
+  const uiConfId = UiConfIdSingleton.getInstance().getUiConfId();
+  if (uiConfId !== '' && window.KalturaPlayers && window.KalturaPlayers[uiConfId]?.config) {
+    return window.KalturaPlayers[uiConfId].config;
+  }
   return window.__kalturaplayerdata || {};
+}
+
+/**
+ * set the UIConfId if exists
+ * @private
+ * @param {PartialKPOptionsObject} options - partial user kaltura player options.
+ * @returns {void}
+ */
+function setUIConfId(options: PartialKPOptionsObject): void {
+  // Store uiConfId if it exists in options
+  if (options.provider && options.provider.uiConfId) {
+    UiConfIdSingleton.getInstance().setUiConfId(options.provider.uiConfId.toString());
+  }
 }
 
 /**
@@ -923,5 +941,6 @@ export {
   initializeStorageManagers,
   maybeLoadInitialServerResponse,
   KALTURA_PLAYER_START_TIME_QS,
-  getLogBuffer
+  getLogBuffer,
+  setUIConfId
 };

--- a/src/common/utils/ui-conf-id-singleton.ts
+++ b/src/common/utils/ui-conf-id-singleton.ts
@@ -1,0 +1,23 @@
+export class UiConfIdSingleton {
+  private static instance: UiConfIdSingleton;
+  private uiConfId: string;
+
+  private constructor() {
+    this.uiConfId = ''; // Initialize with an empty string
+  }
+
+  public static getInstance(): UiConfIdSingleton {
+    if (!UiConfIdSingleton.instance) {
+      UiConfIdSingleton.instance = new UiConfIdSingleton();
+    }
+    return UiConfIdSingleton.instance;
+  }
+
+  public setUiConfId(id: string): void {
+    this.uiConfId = id;
+  }
+
+  public getUiConfId(): string {
+    return this.uiConfId;
+  }
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -17,7 +17,8 @@ import {
   supportLegacyOptions,
   validateConfig,
   validateProviderConfig,
-  maybeLoadInitialServerResponse
+  maybeLoadInitialServerResponse,
+  setUIConfId
 } from './common/utils/setup-helpers';
 import { PartialKPOptionsObject } from './types';
 
@@ -31,6 +32,7 @@ function setup(options: PartialKPOptionsObject): KalturaPlayer {
   printKalturaPlayerVersionToLog(options);
   options = supportLegacyOptions(options);
   validateConfig(options);
+  setUIConfId(options);
   const defaultOptions = getDefaultOptions(options);
   validateProviderConfig(defaultOptions);
   setLogOptions(defaultOptions);

--- a/src/types/global/globals.d.ts
+++ b/src/types/global/globals.d.ts
@@ -7,3 +7,4 @@ declare var __NAME__: string;
 declare var __VERSION__: string;
 declare var __PLAYER_TYPE__: string;
 declare var __PACKAGE_URL__: string;
+declare var KalturaPlayers: any;


### PR DESCRIPTION
### Description of the Changes

Support the new structure `KalturaPlayers` - an array on `window` which plays a factory role of uiConfs.

- add a singleton class for allowing an access to the uiconf id from `setup-helpers` util
- on `setup()` set the uiconf id (if exists)
- on `getServerUIConf()` try to first get the server configuration from the new `KalturaPlayers` - fallback to `__kalturaplayerdata` for backward compatibility

#### Resolves FEC-14544
