### PR TITLE
fix(SUP-48817): Entries Under Moderation Are Still Playing

### DIFF
--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -4,6 +4,7 @@ const isBackEndError = (error: Error): boolean => error.category === 2;
 const isBlockAction = (error: Error): boolean => error.code === 2001;
 const isMediaNotReady = (error: Error): boolean => error.code === 2002;
 const isScheduledRestrictedCode = (error: Error): boolean => error.code === 2003;
+const isModerationRestrictedCode = (error: Error): boolean => error.code === 2004;
 const isGeolocationRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'COUNTRY_RESTRICTED';
 const isSessionRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SESSION_RESTRICTED';
 const isIPRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'IP_RESTRICTED';
@@ -17,6 +18,7 @@ const isIPRestrictedError = (error: Error): boolean => isBackEndError(error) && 
 const isSitedRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSitedRestricted(error);
 const isScheduledRestrictedError = (error: Error): boolean =>
   isBackEndError(error) && isScheduledRestrictedCode(error) && isScheduledRestricted(error);
+const isModerationRestrictedError = (error: Error): boolean => isBackEndError(error) && isModerationRestrictedCode(error);
 const isAccessControlRestrictedError = (error: Error): boolean => {
   return (
     isBackEndError(error) &&
@@ -25,7 +27,8 @@ const isAccessControlRestrictedError = (error: Error): boolean => {
     !isSessionRestricted(error) &&
     !isIPRestricted(error) &&
     !isSitedRestricted(error) &&
-    !isScheduledRestricted(error)
+    !isScheduledRestricted(error) &&
+    !isModerationRestrictedError(error)
   );
 };
 const isDRMError = (error: Error): boolean => error.code < 7000 && error.code >= 6000;
@@ -37,7 +40,8 @@ const conditionsToErrors: any[] = [
   [isIPRestrictedError, Error.Category.IP_RESTRICTED],
   [isScheduledRestrictedError, Error.Category.SCHEDULED_RESTRICTED],
   [isSitedRestrictedError, Error.Category.SITE_RESTRICTED],
-  [isAccessControlRestrictedError, Error.Category.ACCESS_CONTROL_BLOCKED]
+  [isAccessControlRestrictedError, Error.Category.ACCESS_CONTROL_BLOCKED],
+  [isModerationRestrictedError, Error.Category.MODERATION_RESTRICTED]
 ];
 
 function getErrorCategory(error: Error): number {


### PR DESCRIPTION
### Description of the Changes

Adding error handling to moderation restriction

Part of https://github.com/kaltura/playkit-js/pull/822, https://github.com/kaltura/playkit-js-ui/pull/1053, https://github.com/kaltura/playkit-js-providers/pull/265

#### [SUP-48817](https://kaltura.atlassian.net/browse/SUP-48817)


[SUP-48817]: https://kaltura.atlassian.net/browse/SUP-48817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ