### PR TITLE
fix(FEC-14517): Add handling for preload

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -941,8 +941,14 @@ export class KalturaPlayer extends FakeEventTarget {
     if (matchingFallbackSources) {
       const sources = Utils.Object.mergeDeep({}, this._localPlayer.sources, matchingFallbackSources);
       const mediaConfig: any = { sources };
+      // if play was triggered for the original source, firstPlay will be false
+      const shouldPlay = !this._firstPlay;
+
       this.setMedia(mediaConfig);
-      this.play();
+
+      if (shouldPlay) {
+        this.play();
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

When playback.preload is active, we don't want to play the fallback source immediately on drm error, because play() hasn't been called yet on the original source (the original source was loaded because of the preload, not because of play).

In case preload is not active, if the fallback source has been loaded it means that play() was already called on the original source, so we want to also play the fallback source.

Resolves FEC-14517
