### PR TITLE
fix(FEC-14517): Fix thumbnails being loaded without ks on fallback source

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -940,7 +940,7 @@ export class KalturaPlayer extends FakeEventTarget {
     );
     if (matchingFallbackSources) {
       const sources = Utils.Object.mergeDeep({}, this._localPlayer.sources, matchingFallbackSources);
-      const mediaConfig: any = { sources };
+      const mediaConfig: any = { sources, session: this.config.session };
       // if play was triggered for the original source, firstPlay will be false
       const shouldPlay = !this._firstPlay;
 


### PR DESCRIPTION
### Description of the Changes

Add session data to fallback sources, because if loadThumbnailWithKs is true the thumbnails need session data in sources to get the ks from

Resolves FEC-14517
