### PR TITLE
fix(SUP-49704): [Bloomberg] Latest V7 player does not play audio

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@playkit-js/playkit-js-providers": "^2.44.0-canary.0-a2d1ace",
     "@playkit-js/playkit-js-ui": "0.82.6-canary.0-be5e3db",
     "@playkit-js/webpack-common": "^1.0.3",
-    "hls.js": "1.6.0",
+    "hls.js": "1.5.8",
     "shaka-player": "4.14.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@playkit-js/playkit-js": "0.84.30",
     "@playkit-js/playkit-js-dash": "1.39.1",
-    "@playkit-js/playkit-js-hls": "1.32.19",
+    "@playkit-js/playkit-js-hls": "1.32.20-canary.0-2b0ed94",
     "@playkit-js/playkit-js-providers": "^2.44.0-canary.0-a2d1ace",
     "@playkit-js/playkit-js-ui": "0.82.6-canary.0-be5e3db",
     "@playkit-js/webpack-common": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,10 +3483,10 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.6.0.tgz#ec0118f1dcd0fce536e52c27f674cdf944055b30"
-  integrity sha512-AlW8ymcDKZuKtzXCUmEy4nOcHRkebnShH6t6hC2+QJQP0WXlTUSSO9Kp22uSEYdCgpwkXEJsfOhqxrgO2tDctQ==
+hls.js@1.5.8:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.5.8.tgz#73c3d2984a56f103e6900bf7a5e65b288dba846e"
+  integrity sha512-hJYMPfLhWO7/7+n4f9pn6bOheCGx0WgvVz7k3ouq3Pp1bja48NN+HeCQu3XCGYzqWQF/wo7Sk6dJAyWVJD8ECA==
 
 hoist-non-react-statics@^3.3.0:
   version "3.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,10 +1179,10 @@
   dependencies:
     "@playkit-js/webpack-common" "^1.0.3"
 
-"@playkit-js/playkit-js-hls@1.32.19":
-  version "1.32.19"
-  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.32.19.tgz#37c7ec6af72f74802c962be7c07618d1c245e08d"
-  integrity sha512-E3AkzbESoFWILorc4k/x134ZUXv0IDvR0E5/7mhl2meRTanz6KMqJg45Ym9hK4DAeBn0hbZhPfmqhSgUYcbY8A==
+"@playkit-js/playkit-js-hls@1.32.20-canary.0-2b0ed94":
+  version "1.32.20-canary.0-2b0ed94"
+  resolved "https://registry.yarnpkg.com/@playkit-js/playkit-js-hls/-/playkit-js-hls-1.32.20-canary.0-2b0ed94.tgz#cf83f1f0e4c4d13e82c22a1e277bdee4bfc7c060"
+  integrity sha512-dHMlnb188MeoOIGHUIHJmA8mP8134QP59x5SVRNBPPLJcpRhHI+1w+LKW+tRcwoNmy5LTKxHutOzEXjNcYzq8w==
 
 "@playkit-js/playkit-js-providers@^2.44.0-canary.0-a2d1ace":
   version "2.44.0-canary.0-a2d1ace"


### PR DESCRIPTION
### Description of the Changes

Audio only doesn't play with hls 1.6.0

#### Resolves [SUP-49704](https://kaltura.atlassian.net/browse/SUP-49704)


[SUP-49704]: https://kaltura.atlassian.net/browse/SUP-49704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ