### PR TITLE
feat(FEC-14710): Player UI display of EAD on scrubber timeline + real-time updates of cuepoints and scrubber position

### DIFF
--- a/src/common/cuepoint/cuepoint-manager.ts
+++ b/src/common/cuepoint/cuepoint-manager.ts
@@ -84,7 +84,7 @@ export class CuePointManager {
     return false;
   }
 
-  public addCuePoints(data: CuePoint[]): void {
+  public addCuePoints(data: CuePoint[], isExternal?: boolean): void {
     this._player.ready().then(() => {
       if (this._shouldAddTextTrack()) {
         this._addTextTrack();
@@ -99,11 +99,14 @@ export class CuePointManager {
         this._textTrack?.addCue(textTrackCue!);
         timedMetadataArr.push(createTimedMetadata(textTrackCue!)!);
       });
+      let eventPayload = {cues: timedMetadataArr}
+      if (isExternal){
+        //@ts-ignore
+        eventPayload = {...eventPayload, isExternal: true}
+      }
 
       this._player.dispatchEvent(
-        new FakeEvent(EventType.TIMED_METADATA_ADDED, {
-          cues: timedMetadataArr
-        })
+        new FakeEvent(EventType.TIMED_METADATA_ADDED, eventPayload)
       );
     });
   }

--- a/src/common/cuepoint/cuepoint-manager.ts
+++ b/src/common/cuepoint/cuepoint-manager.ts
@@ -99,15 +99,13 @@ export class CuePointManager {
         this._textTrack?.addCue(textTrackCue!);
         timedMetadataArr.push(createTimedMetadata(textTrackCue!)!);
       });
-      let eventPayload = {cues: timedMetadataArr}
-      if (isExternal){
-        //@ts-ignore
-        eventPayload = {...eventPayload, isExternal: true}
+      let eventPayload = { cues: timedMetadataArr };
+      if (isExternal) {
+        //@ts-expect-error - add to TimedMetadata
+        eventPayload = { ...eventPayload, isExternal: true };
       }
 
-      this._player.dispatchEvent(
-        new FakeEvent(EventType.TIMED_METADATA_ADDED, eventPayload)
-      );
+      this._player.dispatchEvent(new FakeEvent(EventType.TIMED_METADATA_ADDED, eventPayload));
     });
   }
 


### PR DESCRIPTION
### Description of the Changes

Adding isExternal to addCuePoints in order to know if this is coming from external app.
if yes send it on the event payload so who is listening to this event (in this case AAD plugin) can get this information.

#### Resolves [FEC-14710](https://kaltura.atlassian.net/browse/FEC-14710)


[FEC-14710]: https://kaltura.atlassian.net/browse/FEC-14710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ