### PR TITLE
feat(FEC-14949): Add entryId configuration support to Logo, Watermark, Error Slate and Bumper plugins

### DIFF
--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1349,32 +1349,31 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   private async _configureUiComponentsUrls(): Promise<void> {
-    const components = [
-      { name: 'logo', configKey: 'img' },
-      { name: 'watermark', configKey: 'img' },
-      { name: 'errorOverlay', configKey: 'backgroundUrl' }
-    ];
+    //@ts-expect-error - entriesForUiComponents
+    const entriesForUiComponents = this.config.playback?.entriesForUiComponents;
+    const data: Record<string, string> = {};
 
-    for (const { name, configKey } of components) {
-      const entryId = this.config.ui.components?.[name]?.entryId;
-      if (!entryId) continue;
-
-      try {
-        const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId });
-        if (mediaConfig?.sources?.downloadUrl) {
-          this.configure({
-            ui: {
-              components: {
-                [name]: {
-                  [configKey]: mediaConfig.sources.downloadUrl
-                }
-              }
-            } as any
-          });
+    if (!entriesForUiComponents) {
+      return;
+    }
+    try {
+      const promises = Object.entries(entriesForUiComponents).map(async ([fieldName, entryId]) => {
+        try {
+          const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId });
+          if (mediaConfig?.sources?.downloadUrl) {
+            data[fieldName] = mediaConfig.sources.downloadUrl;
+          }
+        } catch (error) {
+          KalturaPlayer._logger.warn(`Cannot resolve entryId ${entryId} for UI component ${fieldName}`);
         }
-      } catch {
-        KalturaPlayer._logger.warn(`Cannot resolve entryId ${entryId} for UI component ${name}`);
+      });
+      await Promise.all(promises);
+
+      if (Object.keys(data).length > 0) {
+        this.dispatchEvent(new FakeEvent(CoreEventType.COMPONENTS_URLS_LOADED, { data }));
       }
+    } catch (error) {
+      KalturaPlayer._logger.error('Error configuring UI component URLs', error);
     }
   }
 }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -176,6 +176,7 @@ export class KalturaPlayer extends FakeEventTarget {
 
       this.configure({ network: networkConfig });
     }
+    this._configureUiComponentsUrls();
   }
 
   public async loadMedia(mediaInfo: ProviderMediaInfoObject, mediaOptions?: SourcesConfig): Promise<any> {
@@ -1344,6 +1345,36 @@ export class KalturaPlayer extends FakeEventTarget {
           }
         }
       } as any);
+    }
+  }
+
+  private async _configureUiComponentsUrls() {
+    const components = [
+      { name: 'logo', configKey: 'img' },
+      { name: 'watermark', configKey: 'img' },
+      { name: 'errorOverlay', configKey: 'backgroundUrl' }
+    ];
+
+    for (const { name, configKey } of components) {
+      const entryId = this.config.ui.components?.[name]?.entryId;
+      if (!entryId) continue;
+
+      try {
+        const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId });
+        if (mediaConfig?.sources?.downloadUrl) {
+          this.configure({
+            ui: { 
+              components: { 
+                [name]: { 
+                  [configKey]: mediaConfig.sources.downloadUrl 
+                } 
+              }
+            }
+          });
+        }
+      } catch (error) {
+        this.dispatchEvent(new FakeEvent(Error.Code.ERROR, error));
+      }
     }
   }
 }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1348,7 +1348,7 @@ export class KalturaPlayer extends FakeEventTarget {
     }
   }
 
-  private async _configureUiComponentsUrls() {
+  private async _configureUiComponentsUrls(): Promise<void> {
     const components = [
       { name: 'logo', configKey: 'img' },
       { name: 'watermark', configKey: 'img' },
@@ -1363,11 +1363,11 @@ export class KalturaPlayer extends FakeEventTarget {
         const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId });
         if (mediaConfig?.sources?.downloadUrl) {
           this.configure({
-            ui: { 
-              components: { 
-                [name]: { 
-                  [configKey]: mediaConfig.sources.downloadUrl 
-                } 
+            ui: {
+              components: {
+                [name]: {
+                  [configKey]: mediaConfig.sources.downloadUrl
+                }
               }
             }
           });

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1361,7 +1361,7 @@ export class KalturaPlayer extends FakeEventTarget {
         try {
           const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId });
           if (mediaConfig?.sources?.downloadUrl) {
-            data[fieldName] = mediaConfig.sources.downloadUrl;
+            data[fieldName] = mediaConfig.sources.downloadUrl as string;
           }
         } catch (error) {
           KalturaPlayer._logger.warn(`Cannot resolve entryId ${entryId} for UI component ${fieldName}`);

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1349,15 +1349,15 @@ export class KalturaPlayer extends FakeEventTarget {
   }
 
   private async _configureUiComponentsUrls(): Promise<void> {
-    //@ts-expect-error - entriesForUiComponents
-    const entriesForUiComponents = this.config.playback?.entriesForUiComponents;
+    //@ts-expect-error - remove the ts expect error after type is updated
+    const uiComponentData = this.config?.uiComponentData;
     const data: Record<string, string> = {};
 
-    if (!entriesForUiComponents) {
+    if (!uiComponentData) {
       return;
     }
     try {
-      const promises = Object.entries(entriesForUiComponents).map(async ([fieldName, entryId]) => {
+      const promises = Object.entries(uiComponentData).map(async ([fieldName, entryId]) => {
         try {
           const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId as string });
           if (mediaConfig?.sources?.downloadUrl) {
@@ -1370,8 +1370,7 @@ export class KalturaPlayer extends FakeEventTarget {
       await Promise.all(promises);
 
       if (Object.keys(data).length > 0) {
-        //@ts-expect-error - COMPONENTS_URLS_LOADED event
-        this.dispatchEvent(new FakeEvent(CoreEventType.COMPONENTS_URLS_LOADED, { data }));
+        this.dispatchEvent(new FakeEvent('componentdataupdated', { data }));
       }
     } catch {
       KalturaPlayer._logger.error('Error configuring UI component URLs');

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -76,7 +76,8 @@ import {
   SourcesConfig,
   KPEventTypes,
   HEVCConfigObject,
-  MediaCapabilitiesObject
+  MediaCapabilitiesObject,
+  UiConfig
 } from './types';
 import { getErrorCategory, isDRMError } from './common/utils/error-helper';
 import { SessionIdCache } from './common/utils/session-id-cache';
@@ -1369,11 +1370,11 @@ export class KalturaPlayer extends FakeEventTarget {
                   [configKey]: mediaConfig.sources.downloadUrl
                 }
               }
-            }
+            } as any
           });
         }
-      } catch (error) {
-        this.dispatchEvent(new FakeEvent(Error.Code.ERROR, error));
+      } catch{
+        KalturaPlayer._logger.warn(`Cannot resolve entryId ${entryId} for UI component ${name}`);
       }
     }
   }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -76,8 +76,7 @@ import {
   SourcesConfig,
   KPEventTypes,
   HEVCConfigObject,
-  MediaCapabilitiesObject,
-  UiConfig
+  MediaCapabilitiesObject
 } from './types';
 import { getErrorCategory, isDRMError } from './common/utils/error-helper';
 import { SessionIdCache } from './common/utils/session-id-cache';
@@ -1373,7 +1372,7 @@ export class KalturaPlayer extends FakeEventTarget {
             } as any
           });
         }
-      } catch{
+      } catch {
         KalturaPlayer._logger.warn(`Cannot resolve entryId ${entryId} for UI component ${name}`);
       }
     }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1370,10 +1370,11 @@ export class KalturaPlayer extends FakeEventTarget {
       await Promise.all(promises);
 
       if (Object.keys(data).length > 0) {
+        //@ts-expect-error - COMPONENTS_URLS_LOADED event
         this.dispatchEvent(new FakeEvent(CoreEventType.COMPONENTS_URLS_LOADED, { data }));
       }
-    } catch (error) {
-      KalturaPlayer._logger.error('Error configuring UI component URLs', error);
+    } catch {
+      KalturaPlayer._logger.error('Error configuring UI component URLs');
     }
   }
 }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1351,7 +1351,7 @@ export class KalturaPlayer extends FakeEventTarget {
   private async _configureUiComponentsUrls(): Promise<void> {
     //@ts-expect-error - entriesForUiComponents
     const entriesForUiComponents = this.config.playback?.entriesForUiComponents;
-    const data: Record<string, string> = {};
+    const data: Record<string, any> = {};
 
     if (!entriesForUiComponents) {
       return;
@@ -1361,7 +1361,7 @@ export class KalturaPlayer extends FakeEventTarget {
         try {
           const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId });
           if (mediaConfig?.sources?.downloadUrl) {
-            data[fieldName] = mediaConfig.sources.downloadUrl as string;
+            data[fieldName] = mediaConfig.sources.downloadUrl;
           }
         } catch (error) {
           KalturaPlayer._logger.warn(`Cannot resolve entryId ${entryId} for UI component ${fieldName}`);

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1351,7 +1351,7 @@ export class KalturaPlayer extends FakeEventTarget {
   private async _configureUiComponentsUrls(): Promise<void> {
     //@ts-expect-error - entriesForUiComponents
     const entriesForUiComponents = this.config.playback?.entriesForUiComponents;
-    const data: Record<string, any> = {};
+    const data: Record<string, string> = {};
 
     if (!entriesForUiComponents) {
       return;
@@ -1359,7 +1359,7 @@ export class KalturaPlayer extends FakeEventTarget {
     try {
       const promises = Object.entries(entriesForUiComponents).map(async ([fieldName, entryId]) => {
         try {
-          const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId });
+          const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId as string});
           if (mediaConfig?.sources?.downloadUrl) {
             data[fieldName] = mediaConfig.sources.downloadUrl;
           }

--- a/src/kaltura-player.ts
+++ b/src/kaltura-player.ts
@@ -1359,7 +1359,7 @@ export class KalturaPlayer extends FakeEventTarget {
     try {
       const promises = Object.entries(entriesForUiComponents).map(async ([fieldName, entryId]) => {
         try {
-          const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId as string});
+          const mediaConfig = await this._provider.getMediaConfig({ entryId: entryId as string });
           if (mediaConfig?.sources?.downloadUrl) {
             data[fieldName] = mediaConfig.sources.downloadUrl;
           }


### PR DESCRIPTION
### Description of the Changes

Adding support for entryId configuration in logo, errorOverlay and watermark.

checking components configuration to see if entryId is configured.
use getMediaConfig to get the img url.
update the components config with the new url.

related pr - https://github.com/kaltura/playkit-js-ui/pull/1160

#### Resolves [FEC-14949](https://kaltura.atlassian.net/browse/FEC-14949)


[FEC-14949]: https://kaltura.atlassian.net/browse/FEC-14949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ