### PR TITLE
[Triage Fix] SUP-52309: Playlist entry starts at wrong offset due to stale startTime in cached sources

### DIFF
--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -395,6 +395,7 @@ class PlaylistManager {
         // @ts-ignore
         this._player.setMedia(media);
         return this._player.loadMedia(this._mediaInfoList[index]).then((mediaConfig) => {
+          delete mediaConfig.sources.startTime;
           this._playlist.updateItemSources(index, mediaConfig.sources);
           this._playlist.updateItemPlugins(index, mediaConfig.plugins);
 

--- a/tests/e2e/common/playlist/playlist-manager-starttime.spec.ts
+++ b/tests/e2e/common/playlist/playlist-manager-starttime.spec.ts
@@ -1,0 +1,129 @@
+// @ts-nocheck
+/**
+ * Regression test for SUP-52309
+ *
+ * Verifies that a startTime embedded in a loadMedia response (e.g. from KalturaViewHistoryUserEntry)
+ * is NOT carried over to the next _setItem call for the same entry once its sources become playable.
+ *
+ * Root cause: PlaylistManager._setItem stored the full loadMedia response including startTime
+ * via updateItemSources. On replay (when isPlayable() = true), setMedia was called directly
+ * with the cached sources, forwarding the stale startTime to the player engine.
+ *
+ * Fix: delete mediaConfig.sources.startTime before updateItemSources caches the object.
+ */
+import { KalturaPlayer } from '../../../../src/kaltura-player';
+import { PlaylistManager } from '../../../../src/common/playlist/playlist-manager';
+import { PlaylistEventType } from '../../../../src/common/playlist/playlist-event-type';
+
+describe('PlaylistManager - startTime leak (SUP-52309)', () => {
+  let kalturaPlayer, playlistManager, sandbox;
+  const STALE_START_TIME = 15;
+
+  const config = {
+    ui: {},
+    plugins: {},
+    advertising: { adBreaks: [] },
+    provider: {},
+    playback: { autoplay: false }
+  };
+
+  const makeNonPlayableItem = (id) => ({
+    sources: {
+      id,
+      hls: [],
+      dash: [],
+      progressive: []
+    }
+  });
+
+  const makeFullSources = (id, startTime) => ({
+    session: { isAnonymous: true, partnerId: 1091, ks: '' },
+    sources: {
+      id,
+      hls: [
+        {
+          id: `${id}_hls`,
+          url: `http://example.com/p/1091/playManifest/entryId/${id}/format/applehttp/a.m3u8`,
+          mimetype: 'application/x-mpegURL'
+        }
+      ],
+      dash: [
+        {
+          id: `${id}_dash`,
+          url: `http://example.com/p/1091/playManifest/entryId/${id}/format/mpegdash/a.mpd`,
+          mimetype: 'application/dash+xml'
+        }
+      ],
+      progressive: [],
+      duration: 120,
+      type: 'Vod',
+      startTime
+    }
+  });
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    kalturaPlayer = new KalturaPlayer(config);
+  });
+
+  beforeEach(() => {
+    playlistManager = new PlaylistManager(kalturaPlayer, config);
+    kalturaPlayer._eventManager.removeAll();
+    kalturaPlayer.reset();
+  });
+
+  afterEach(() => {
+    playlistManager.reset();
+    playlistManager = null;
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('should NOT carry over startTime from a prior loadMedia response when replaying an item', (done) => {
+    const entryId = '0_starttime_test';
+    const capturedStartTimes = [];
+
+    // Simulate provider returning startTime = 15 from KalturaViewHistoryUserEntry
+    sinon.stub(kalturaPlayer, 'loadMedia').callsFake(() => {
+      return Promise.resolve(makeFullSources(entryId, STALE_START_TIME));
+    });
+
+    // Capture every startTime value passed into setMedia
+    sinon.stub(kalturaPlayer, 'setMedia').callsFake((mediaConfig) => {
+      if (mediaConfig && mediaConfig.sources) {
+        capturedStartTimes.push(mediaConfig.sources.startTime);
+      }
+    });
+
+    let eventCount = 0;
+    kalturaPlayer._eventManager.listen(kalturaPlayer, PlaylistEventType.PLAYLIST_ITEM_CHANGED, () => {
+      eventCount++;
+      if (eventCount === 1) {
+        // First play: sources hydrated via loadMedia (non-playable path).
+        // Sources are now cached on the PlaylistItem — replay to trigger the playable path.
+        kalturaPlayer._reset = false;
+        playlistManager.playItem(0);
+      } else if (eventCount === 2) {
+        kalturaPlayer.setMedia.restore();
+        kalturaPlayer.loadMedia.restore();
+        try {
+          // On replay, setMedia is called directly with cached sources (playable path).
+          // The fix ensures startTime was stripped before caching, so it must be absent here.
+          const replayStartTime = capturedStartTimes[capturedStartTimes.length - 1];
+          (replayStartTime === undefined || replayStartTime === 0).should.be.true;
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }
+    });
+
+    playlistManager.configure({
+      id: 'sup-52309-test',
+      items: [makeNonPlayableItem(entryId)],
+      options: { autoContinue: false }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Jira:** [SUP-52309](https://kaltura.atlassian.net/browse/SUP-52309) — [HSBC-IRP] Playlist entry starts at 00:15 instead of 00:00
- **Repo:** `kaltura/kaltura-player-js`
- **File:** `src/common/playlist/playlist-manager.ts` — `PlaylistManager._setItem`

## Root Cause

When a playlist entry is initially non-playable (empty `hls`/`dash` arrays), `_setItem` calls `loadMedia` to fetch the full sources from the provider. The resolved `mediaConfig.sources` can include a `startTime` value originating from `KalturaViewHistoryUserEntry` (even when `resumePlayback` is disabled at the UI level, the provider may still return last-viewed position data).

This `startTime` was passed verbatim to `PlaylistItem.updateItemSources`, permanently caching it on the `PlaylistItem`. On any subsequent `_setItem` call for the same entry (replay, loop navigation, or re-entry), `isPlayable()` returns `true` and `_setItem` enters the fast path that calls `setMedia(activeItem.sources)` directly — forwarding the stale `startTime = 15` straight to the player engine, causing 00:15 offset playback.

The bug is intermittent because it only manifests on the **second play** of an entry (after its sources have been hydrated by a previous `loadMedia`), and only if `KalturaViewHistoryUserEntry` returns a non-zero last position.

## Fix

```diff
- return this._player.loadMedia(this._mediaInfoList[index]).then((mediaConfig) => {
-   this._playlist.updateItemSources(index, mediaConfig.sources);
+ return this._player.loadMedia(this._mediaInfoList[index]).then((mediaConfig) => {
+   delete mediaConfig.sources.startTime;
+   this._playlist.updateItemSources(index, mediaConfig.sources);
```

Delete `startTime` from `mediaConfig.sources` after `loadMedia` resolves and **before** `updateItemSources` caches the object on the `PlaylistItem`. The one-time seek hint from view history is discarded so it cannot bleed into future replays.

## Test plan

- [ ] Verify existing `PlaylistManager` Mocha spec suite passes (`yarn test` — 272 tests)
- [ ] Confirm fix with regression test from the unit-test validation cycle (SUP-52309 Jira comments)
- [ ] Manual QA: Play playlist `0_56ujm104` on HSBC IRP environment; confirm entry `0_5dktc3p6` starts at 00:00
- [ ] Verify entries with explicit `seekFrom`/`clipTo` (clipping) still seek correctly — `addStartAndEndTime` only appends URL params and is unaffected by this change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[SUP-52309]: https://kaltura.atlassian.net/browse/SUP-52309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ