### PR TITLE
[Player Fix] SUP-52309: Playlist entry starts at wrong offset due to stale startTime in cached sources

### DIFF
--- a/src/common/playlist/playlist-manager.ts
+++ b/src/common/playlist/playlist-manager.ts
@@ -395,6 +395,7 @@ class PlaylistManager {
         // @ts-ignore
         this._player.setMedia(media);
         return this._player.loadMedia(this._mediaInfoList[index]).then((mediaConfig) => {
+          delete mediaConfig.sources.startTime;
           this._playlist.updateItemSources(index, mediaConfig.sources);
           this._playlist.updateItemPlugins(index, mediaConfig.plugins);
 

--- a/tests/e2e/common/playlist/playlist-manager-starttime.spec.ts
+++ b/tests/e2e/common/playlist/playlist-manager-starttime.spec.ts
@@ -1,0 +1,108 @@
+// @ts-nocheck
+/**
+ * Regression test for SUP-52309
+ *
+ * When a playlist entry is initially non-playable (empty hls/dash arrays), _setItem
+ * calls loadMedia to hydrate full sources. The resolved mediaConfig.sources can carry
+ * a startTime value from KalturaViewHistoryUserEntry. Before the fix, this value was
+ * stored verbatim via updateItemSources and forwarded to setMedia on subsequent replays,
+ * causing the entry to start at 00:15 instead of 00:00.
+ */
+import { KalturaPlayer } from '../../../../src/kaltura-player';
+import { PlaylistManager } from '../../../../src/common/playlist/playlist-manager';
+import { PlaylistEventType } from '../../../../src/common/playlist/playlist-event-type';
+
+describe('PlaylistManager - startTime leak (SUP-52309)', () => {
+  let kalturaPlayer, playlistManager, sandbox;
+  const STALE_START_TIME = 15;
+
+  const config = {
+    ui: {},
+    plugins: {},
+    advertising: { adBreaks: [] },
+    provider: {},
+    playback: { autoplay: false }
+  };
+
+  const makeNonPlayableItem = (id) => ({
+    sources: { id, hls: [], dash: [], progressive: [] }
+  });
+
+  const makeFullSources = (id, startTime) => ({
+    session: { isAnonymous: true, partnerId: 1091, ks: '' },
+    sources: {
+      id,
+      hls: [{ id: `${id}_hls`, url: `http://example.com/p/1091/playManifest/entryId/${id}/format/applehttp/a.m3u8`, mimetype: 'application/x-mpegURL' }],
+      dash: [{ id: `${id}_dash`, url: `http://example.com/p/1091/playManifest/entryId/${id}/format/mpegdash/a.mpd`, mimetype: 'application/dash+xml' }],
+      progressive: [],
+      duration: 120,
+      type: 'Vod',
+      startTime
+    }
+  });
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    kalturaPlayer = new KalturaPlayer(config);
+  });
+
+  beforeEach(() => {
+    playlistManager = new PlaylistManager(kalturaPlayer, config);
+    kalturaPlayer._eventManager.removeAll();
+    kalturaPlayer.reset();
+  });
+
+  afterEach(() => {
+    playlistManager.reset();
+    playlistManager = null;
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('should NOT carry over startTime from a prior loadMedia response when replaying an item', (done) => {
+    const entryId = '0_starttime_test';
+    const capturedStartTimes = [];
+
+    // Simulate provider returning startTime = 15 (KalturaViewHistoryUserEntry last-position)
+    sinon.stub(kalturaPlayer, 'loadMedia').callsFake(() => {
+      return Promise.resolve(makeFullSources(entryId, STALE_START_TIME));
+    });
+
+    // Spy on every setMedia call to record startTime values
+    sinon.stub(kalturaPlayer, 'setMedia').callsFake((mediaConfig) => {
+      if (mediaConfig && mediaConfig.sources) {
+        capturedStartTimes.push(mediaConfig.sources.startTime);
+      }
+    });
+
+    let eventCount = 0;
+    kalturaPlayer._eventManager.listen(kalturaPlayer, PlaylistEventType.PLAYLIST_ITEM_CHANGED, () => {
+      eventCount++;
+      if (eventCount === 1) {
+        // First play: loadMedia resolved, sources with startTime=15 stored on PlaylistItem.
+        // Replay the item — now isPlayable() is true, so _setItem uses the direct setMedia path.
+        kalturaPlayer._reset = false;
+        playlistManager.playItem(0);
+      } else if (eventCount === 2) {
+        kalturaPlayer.setMedia.restore();
+        kalturaPlayer.loadMedia.restore();
+        try {
+          // The replay setMedia call must NOT carry startTime = 15
+          const replayStartTime = capturedStartTimes[capturedStartTimes.length - 1];
+          (replayStartTime === undefined || replayStartTime === 0).should.be.true;
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }
+    });
+
+    playlistManager.configure({
+      id: 'sup-52309-test',
+      items: [makeNonPlayableItem(entryId)],
+      options: { autoContinue: false }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Playlist entry `0_5dktc3p6` in HSBC IRP starts at 00:15 instead of 00:00 when played from dedicated playlist view
- Root cause: `startTime` from `KalturaViewHistoryUserEntry` was persisted on the `PlaylistItem` cache and forwarded to `setMedia` on replay
- Fix: one-line delete of `mediaConfig.sources.startTime` in `PlaylistManager._setItem` before `updateItemSources`

## Root Cause

When a playlist entry is initially non-playable (empty `hls`/`dash` arrays), `_setItem` calls `loadMedia` to hydrate full sources. The resolved `mediaConfig.sources` can carry a `startTime` from `KalturaViewHistoryUserEntry` even when `resumePlayback` is disabled at the UI level. This value was stored verbatim via `updateItemSources`, making it persist on the `PlaylistItem`. On any subsequent `_setItem` call (replay, loop, re-navigation), `isPlayable()` returns `true` and `setMedia` is called directly with the cached sources, forwarding `startTime = 15` to the player engine.

## Before / After

```diff
  return this._player.loadMedia(this._mediaInfoList[index]).then((mediaConfig) => {
+   delete mediaConfig.sources.startTime;
    this._playlist.updateItemSources(index, mediaConfig.sources);
```

## Steps to Reproduce

1. Open a dedicated KMS playlist with `resumePlayback` disabled
2. Let the first entry play past 00:00 so `KalturaViewHistoryUserEntry` records a last-viewed position (~15s)
3. Replay the same entry or trigger auto-continue back to it
4. Entry restarts at 00:15 instead of 00:00

## Red / Green Evidence

| Phase | Result |
|-------|--------|
| RED (before fix) | 272 passed, **1 FAILED** — `AssertionError: expected false to be true` |
| GREEN (after fix) | **273 passed, 0 failed** |

## Test plan

- [x] New regression spec: `tests/e2e/common/playlist/playlist-manager-starttime.spec.ts`
- [ ] Manual QA: replay entry `0_5dktc3p6` in HSBC IRP playlist `0_56ujm104` — confirm 00:00 start
- [ ] Verify entries with explicit `seekFrom`/`clipTo` (clipping) still seek correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)