### PR TITLE
fix(ADA-3093): Remove Talkback stop

### DIFF
--- a/src/common/utils/setup-helpers.ts
+++ b/src/common/utils/setup-helpers.ts
@@ -127,7 +127,6 @@ function createKalturaPlayerContainer(targetId: string): string {
   const el = document.createElement('div');
   el.id = Utils.Generator.uniqueId(5);
   el.className = CONTAINER_CLASS_NAME;
-  el.setAttribute('tabindex', '-1');
   const parentNode = document.getElementById(targetId);
   if (parentNode && el) {
     parentNode.appendChild(el);


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-3093
### Description of the Changes

The ticket's issue is multiple swipes when reaching pre-playback button while using android Talkback. Talkback sees the player container as an accessibility node, because of the use of tabindex="-1". Tabindex="-1" should be used to stop focusing an interactive item or to make it be focused programmatically. None of these cases is being used here, so removing it fixes one of the multiple swipes for Talkback.

**Issue:**

**Fix:**

#### Resolves FEC-[Please add the ticket reference here]
