### PR TITLE
fix(player): guard against empty messages array in error-helper (SUP-52847)

### DIFF
--- a/src/common/utils/error-helper.ts
+++ b/src/common/utils/error-helper.ts
@@ -5,11 +5,11 @@ const isBlockAction = (error: Error): boolean => error.code === 2001;
 const isMediaNotReady = (error: Error): boolean => error.code === 2002;
 const isScheduledRestrictedCode = (error: Error): boolean => error.code === 2003;
 const isDeletedEntryCode = (error: Error): boolean => error.code === 2004;
-const isGeolocationRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'COUNTRY_RESTRICTED';
-const isSessionRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SESSION_RESTRICTED';
-const isIPRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'IP_RESTRICTED';
-const isSitedRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SITE_RESTRICTED';
-const isScheduledRestricted = (error: Error): boolean => error.data?.messages && error.data?.messages[0].code === 'SCHEDULED_RESTRICTED';
+const isGeolocationRestricted = (error: Error): boolean => error.data?.messages?.[0]?.code === 'COUNTRY_RESTRICTED';
+const isSessionRestricted = (error: Error): boolean => error.data?.messages?.[0]?.code === 'SESSION_RESTRICTED';
+const isIPRestricted = (error: Error): boolean => error.data?.messages?.[0]?.code === 'IP_RESTRICTED';
+const isSitedRestricted = (error: Error): boolean => error.data?.messages?.[0]?.code === 'SITE_RESTRICTED';
+const isScheduledRestricted = (error: Error): boolean => error.data?.messages?.[0]?.code === 'SCHEDULED_RESTRICTED';
 
 const isSessionRestrictedError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isSessionRestricted(error);
 const isGeolocationError = (error: Error): boolean => isBackEndError(error) && isBlockAction(error) && isGeolocationRestricted(error);

--- a/tests/e2e/common/utils/error-helper.spec.ts
+++ b/tests/e2e/common/utils/error-helper.spec.ts
@@ -1,0 +1,89 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { getErrorCategory } from '../../../../src/common/utils/error-helper';
+import { Error } from '@playkit-js/playkit-js';
+
+describe('error-helper', () => {
+  describe('getErrorCategory — geo-block with empty messages array', () => {
+    it('should return GEO_LOCATION when messages array has COUNTRY_RESTRICTED code', () => {
+      const error = {
+        category: 2,
+        code: 2001,
+        data: { messages: [{ code: 'COUNTRY_RESTRICTED' }] }
+      };
+      getErrorCategory(error as any).should.equal(Error.Category.GEO_LOCATION);
+    });
+
+    it('should NOT throw and should return ACCESS_CONTROL_BLOCKED when messages is an empty array', () => {
+      const error = {
+        category: 2,
+        code: 2001,
+        data: { messages: [] }
+      };
+      // Before the fix this threw a TypeError: Cannot read properties of undefined (reading 'code')
+      ((): void => {
+        getErrorCategory(error as any);
+      }).should.not.throw();
+      getErrorCategory(error as any).should.equal(Error.Category.ACCESS_CONTROL_BLOCKED);
+    });
+
+    it('should NOT throw and should return ACCESS_CONTROL_BLOCKED when messages is undefined', () => {
+      const error = {
+        category: 2,
+        code: 2001,
+        data: {}
+      };
+      ((): void => {
+        getErrorCategory(error as any);
+      }).should.not.throw();
+      getErrorCategory(error as any).should.equal(Error.Category.ACCESS_CONTROL_BLOCKED);
+    });
+
+    it('should NOT throw and should return ACCESS_CONTROL_BLOCKED when data itself is undefined', () => {
+      const error = {
+        category: 2,
+        code: 2001
+      };
+      ((): void => {
+        getErrorCategory(error as any);
+      }).should.not.throw();
+      getErrorCategory(error as any).should.equal(Error.Category.ACCESS_CONTROL_BLOCKED);
+    });
+
+    it('should return SESSION_RESTRICTED category when messages has SESSION_RESTRICTED code', () => {
+      const error = {
+        category: 2,
+        code: 2001,
+        data: { messages: [{ code: 'SESSION_RESTRICTED' }] }
+      };
+      getErrorCategory(error as any).should.equal(Error.Category.MEDIA_UNAVAILABLE);
+    });
+
+    it('should return IP_RESTRICTED category when messages has IP_RESTRICTED code', () => {
+      const error = {
+        category: 2,
+        code: 2001,
+        data: { messages: [{ code: 'IP_RESTRICTED' }] }
+      };
+      getErrorCategory(error as any).should.equal(Error.Category.IP_RESTRICTED);
+    });
+
+    it('should return SITE_RESTRICTED category when messages has SITE_RESTRICTED code', () => {
+      const error = {
+        category: 2,
+        code: 2001,
+        data: { messages: [{ code: 'SITE_RESTRICTED' }] }
+      };
+      getErrorCategory(error as any).should.equal(Error.Category.SITE_RESTRICTED);
+    });
+
+    it('should return SCHEDULED_RESTRICTED category when messages has SCHEDULED_RESTRICTED code', () => {
+      const error = {
+        category: 2,
+        code: 2003,
+        data: { messages: [{ code: 'SCHEDULED_RESTRICTED' }] }
+      };
+      getErrorCategory(error as any).should.equal(Error.Category.SCHEDULED_RESTRICTED);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Geo-blocked VOD content outside Israel (customer 2748741 / Reshet / 13tv.co.il) shows an infinite loader instead of the proper geo-block / access-control error screen.

## Root Cause

In `src/common/utils/error-helper.ts`, all 5 restriction checks used this pattern:

\`\`\`ts
error.data?.messages && error.data?.messages[0].code === 'X'
\`\`\`

When the Kaltura API returns a BLOCK action with `messages: []` (empty array), `error.data?.messages` evaluates to `[]` which is **truthy** in JavaScript. The chain then proceeds to `messages[0]` which is `undefined`, and `undefined.code` throws a **TypeError**.

This uncaught TypeError propagates out of `getErrorCategory()`, preventing the ERROR event from ever being dispatched. Result: `hasError` stays `false`, the loading spinner stays visible indefinitely — the error screen never renders.

## Solution

Replaced the unguarded array access with optional chaining in all 5 restriction checks:

\`\`\`ts
// Before
error.data?.messages && error.data?.messages[0].code === 'X'

// After
error.data?.messages?.[0]?.code === 'X'
\`\`\`

When `messages: []`, the checks now safely return `false` instead of throwing, allowing `isAccessControlRestrictedError` to match and the correct error screen to render.

## Test Coverage

- [x] Added regression test: `tests/e2e/common/utils/error-helper.spec.ts`
- [x] All existing tests pass
- [x] Manual verification: BEFORE build shows infinite loader, AFTER build shows error screen

## Related

- Jira: https://kaltura.atlassian.net/browse/SUP-52847

## Checklist

- [ ] Code reviewed
- [ ] No regressions introduced
- [ ] Test covers the failure case